### PR TITLE
This pull request add a convenient ui object to get DOM elements on the page

### DIFF
--- a/shared/base/view.coffee
+++ b/shared/base/view.coffee
@@ -169,8 +169,21 @@ module.exports = class BaseView extends Backbone.View
   # Anything to do after rendering on the client.
   _postRender: ->
     @attachChildViews()
+    @_bindUIElements()
     @postRender()
     @trigger 'postRender'
+
+  _bindUIElements: ->
+    if !@ui 
+      return
+
+    if !@uiBindings
+      @uiBindings = _.result(@, "ui");
+
+    @ui = {}
+    _.each _.keys(@uiBindings), (key) =>
+      selector = @uiBindings[key]
+      @ui[key] = @$(selector)
 
   # To be overridden by subclasses.
   preRender: noop


### PR DESCRIPTION
use case:

class TestView extends BaseView

  events: 
    "click .test" : "doTest"

  template: "test_template"

  ui:
    testButton: ".test"

  doTest: (e)->
    @ui.testButton.text("new text")
