### PR TITLE
Fix syncer typo and use emulateJSON in options.

### DIFF
--- a/shared/syncer.coffee
+++ b/shared/syncer.coffee
@@ -11,9 +11,9 @@ methodMap =
 clientSync = (method, model, options) ->
   data = _.clone options.data
   options.url = @getUrl(options.url, true, data)
-  Backbone.emulateJSON = true
   data = addApiParams(method, model, data)
   options.data = data
+  options.emulateJSON = true
   Backbone.sync(method, model, options)
 
 serverSync = (method, model, options) ->


### PR DESCRIPTION
Fixed typo in syncer and changed emulateJSON to be set in fetch options instead of polluting Backone.emulateJSON. emulateJSON can be set in fetch options in Backbone >=0.9.9.
