### PR TITLE
Remove child views on re-render

### DIFF
--- a/shared/base/view.coffee
+++ b/shared/base/view.coffee
@@ -238,6 +238,8 @@ module.exports = class BaseView extends Backbone.View
   # Call @getView()
   # Attach childView
   attachChildViews: ->
+    # Remove all child views in case we are re-rendering through
+    # manual .render() or 'refresh' being triggered on the view.
     @removeChildViews()
     @childViews = BaseView.attach(@app, @)
 


### PR DESCRIPTION
Noticed that subviews aren't closed on re-render. Figured this would work?
