### PR TITLE
Fixing localstorage check. Breaks on some Android phones

### DIFF
--- a/shared/store/local_storage_store.coffee
+++ b/shared/store/local_storage_store.coffee
@@ -28,4 +28,7 @@ module.exports = class LocalStorageStore extends MemoryStore
     @_keys = {}
 
   @canHaz = ->
-    window?.localStorage?
+    try
+      window?.localStorage?
+    catch e
+      return false


### PR DESCRIPTION
Touching window.localstorage throws an exception on some Android phones and browsers with tighter settings. DOM Exception 18
