### PR TITLE
Use process.cwd() instead of process.env.PWD

### DIFF
--- a/shared/globals.coffee
+++ b/shared/globals.coffee
@@ -9,4 +9,4 @@ else
   global.Backbone = require('backbone')
   global.Handlebars = require('handlebars')
   global.rendr =
-    entryPath: process.env.PWD
+    entryPath: process.cwd()


### PR DESCRIPTION
I had problems running rendr app on nodejitsu.

process.env.PWD is not set properly by all shells, 
its more convinient to use process.cwd() instead.

And have greater control of current working directory.

Thanks.
