### PR TITLE
Added Travis CI and fixed collection store test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "0.11"
+  - "0.10"
+  - "0.8"
+notifications:
+  email: false

--- a/test/shared/store/collection_store.test.coffee
+++ b/test/shared/store/collection_store.test.coffee
@@ -52,10 +52,11 @@ describe 'CollectionStore', ->
 
     collection = new MyCollection(models, meta: meta, params: params)
     @store.set collection, params
+    modelUtils.addClassMapping collection.constructor.name, MyCollection
     results = @store.get collection.constructor.name, params
     results.should.eql
       ids: collection.pluck('login')
-      meta: meta    
+      meta: meta
 
   it "should treat different params as different collections", ->
     models0 = [{


### PR DESCRIPTION
# Travis CI

I thought it would be helpful to utilize [Travis CI](https://travis-ci.org/) for making sure that pull requests/commits pass the test suite. The `.travis.yml` configuration file I added runs the test suite against node versions 0.11, 0.10, and 0.8 on every commit and pull request. I also disabled email notifications so you don't get spammed. You can read more about travis notification settings [here](http://about.travis-ci.org/docs/user/notifications/).

When I initially ran the test suite on Travis, I was occasionally getting an error with the collection store test. [Here](https://travis-ci.org/ChrisWren/rendr/jobs/6208164) is an example test run that produced the error. The tests worked fine on my OSX machine, but as you can see in Travis there is an error where the `my_collection` node module wasn't found.
# Collection Store Test

After looking at the collection store test, I realized that the `modelUtils` provides a `addClassMapping` method to register classes using the collection constructor as an argument instead of the path name to the collection file.

However, the `my_collection` class wasn't being added to the classMap before calling `@store.get`, and in turn the collection store was looking for a non-existant collection file. To resolve this, I added the class to the mapping before calling `@store.get`.

I am not sure if you have used Travis before, so if you have any questions let me know.
