### PR TITLE
Make sure that the model's id is converted to string so it would be included in the BaseView attributes.

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -164,7 +164,7 @@ module.exports = BaseView = Backbone.View.extend({
       if (value != null) {
         if (key === 'model') {
           key = 'model_id';
-          value = value.id;
+          value = value.id.toString();
         } else if (key === 'collection') {
           key = 'collection_params';
           value = _.escape(JSON.stringify(value.params));


### PR DESCRIPTION
Make sure that the model's `id` is converted to string so it would be included in the attributes.

This commit should close the issue #25. In that issue, server side ids are Mongoose `ObjectId`, so they would not be included to `BaseView` attributes.
