### PR TITLE
ECMAScript 5 refactor: inherit-component to Object.create

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -1,8 +1,7 @@
 /*global rendr*/
 
-var AppView, Backbone, BaseRouter, BaseView, ClientRouter, extractParamNamesRe, firstRender, plusRe, _, inherit;
+var AppView, Backbone, BaseRouter, BaseView, extractParamNamesRe, firstRender, plusRe, _;
 
-inherit = require('inherit-component');
 _ = require('underscore');
 Backbone = require('backbone');
 BaseRouter = require('../shared/base/router');
@@ -29,7 +28,10 @@ function ClientRouter(options) {
   BaseRouter.apply(this, arguments);
 }
 
-inherit(ClientRouter, BaseRouter);
+ClientRouter.prototype = Object.create(
+  BaseRouter.prototype,
+  {constructor: {value: ClientRouter}}
+);
 
 ClientRouter.prototype.currentFragment = null;
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "async":"0.1.22",
     "qs": "0.5.1",
     "express": "~3.0.6",
-    "validator": "0.4.21",
-    "inherit-component": "0.0.2"
+    "validator": "0.4.21"
   },
   "devDependencies": {
     "mocha": "*",

--- a/server/router.js
+++ b/server/router.js
@@ -1,6 +1,5 @@
-var BaseRouter, ServerRouter, sanitize, _, inherit;
+var BaseRouter, sanitize, _;
 
-inherit = require('inherit-component');
 _ = require('underscore');
 BaseRouter = require('../shared/base/router');
 sanitize = require('validator').sanitize;
@@ -11,7 +10,10 @@ function ServerRouter() {
   BaseRouter.apply(this, arguments);
 }
 
-inherit(ServerRouter, BaseRouter);
+ServerRouter.prototype = Object.create(
+  BaseRouter.prototype,
+  {constructor: {value: ServerRouter}}
+);
 
 ServerRouter.prototype.escapeParams = function(params) {
   var escaped = {};

--- a/shared/store/collection_store.js
+++ b/shared/store/collection_store.js
@@ -1,6 +1,5 @@
-var MemoryStore, Super, modelUtils, _, inherit;
+var MemoryStore, Super, modelUtils, _;
 
-inherit = require('inherit-component');
 _ = require('underscore');
 Super = MemoryStore = require('./memory_store');
 modelUtils = require('../modelUtils');
@@ -11,7 +10,10 @@ function CollectionStore() {
   Super.apply(this, arguments);
 }
 
-inherit(CollectionStore, Super);
+CollectionStore.prototype = Object.create(
+  Super.prototype,
+  {constructor: {value: CollectionStore}}
+);
 
 CollectionStore.prototype.set = function(collection, params) {
   var data, idAttribute, key;

--- a/shared/store/model_store.js
+++ b/shared/store/model_store.js
@@ -1,6 +1,5 @@
-var MemoryStore, Super, modelUtils, _, inherit;
+var MemoryStore, Super, modelUtils, _;
 
-inherit = require('inherit-component');
 _ = require('underscore');
 Super = MemoryStore = require('./memory_store');
 modelUtils = require('../modelUtils');
@@ -11,7 +10,10 @@ function ModelStore() {
   Super.apply(this, arguments);
 }
 
-inherit(ModelStore, Super);
+ModelStore.prototype = Object.create(
+  Super.prototype,
+  {constructor: {value: ModelStore}}
+);
 
 ModelStore.prototype.set = function(model) {
   var existingAttrs, id, key, modelName, newAttrs;


### PR DESCRIPTION
Refactored usages of inherit-component with assigning prototypes using Object.create
Removed dependency to inherit-component in package.json
Cleaned up duplicate declarations of ServerRouter and ClientRouter

This is to respond in part to issue #22
