### PR TITLE
Make context available to layout template

### DIFF
--- a/server/viewEngine.js
+++ b/server/viewEngine.js
@@ -30,6 +30,7 @@ function viewEngine(viewPath, data, callback) {
 * render with a layout
 */
 function renderWithLayout(locals, callback) {
+  _.extend(locals, locals.locals);
   getLayoutTemplate(function(err, templateFn) {
     if (err) return callback(err);
     var html = templateFn(locals);


### PR DESCRIPTION
Make context available when rendering __layout.hbs.
- `{{foo}}` instead of `{{locals.foo}}`
- Partials work in __layout
