### PR TITLE
View template directory structures

### DIFF
--- a/server/viewEngine.js
+++ b/server/viewEngine.js
@@ -64,7 +64,7 @@ function getViewHtml(viewPath, locals, app) {
 
   // Pass in the app.
   locals.app = app;
-  name = path.basename(viewPath);
+  name = BaseView.getViewName(viewPath);
   View = BaseView.getView(name);
   view = new View(locals);
   return view.getHtml();

--- a/test/shared/base/view.test.js
+++ b/test/shared/base/view.test.js
@@ -31,4 +31,43 @@ describe('BaseView', function() {
     childViews = topView.getChildViewsByName('my_bottom_view');
     childViews.should.have.length(2);
   });
+
+  describe('getViewNamePermutations', function() {
+    it('should return multiple view/template directory options', function() {
+        var conditionsIndex = 'conditions_index_view';
+            conditionsViewOpts = [
+                'conditions_index_view',
+                'conditions/index',
+                'conditions/index_view'
+            ],
+            fooShow = 'foo_show',
+            fooShowViewOpts = [
+                'foo_show',
+                'foo/show'
+            ],
+            coolFeatureIndex = 'my_cool_feature_index_view',
+            coolFeatureViewOpts = [
+                'my_cool_feature_index_view',
+                'my_cool_feature/index',
+                'my_cool_feature/index_view',
+                'my/cool/feature/index',
+                'my/cool/feature/index_view'
+            ];
+
+        BaseView.getViewNamePermutations(conditionsIndex).should.eql(conditionsViewOpts);
+        BaseView.getViewNamePermutations(fooShow).should.eql(fooShowViewOpts);
+        BaseView.getViewNamePermutations(coolFeatureIndex).should.eql(coolFeatureViewOpts);
+    });
+  });
+
+  describe('safeGet', function() {
+    it('should return the correct value', function() {
+        BaseView.safeGet('some_view_name', function(v){ return v;}).should.eql('some_view_name');
+        BaseView.safeGet('some_view_name', function(v){ return v;}, 'PRE_').should.eql('PRE_some_view_name');
+    });
+    it('should fail silently', function() {
+        should.not.exist( BaseView.safeGet('a_string', function(v) { return v.join(); }) );
+    });
+  });
+
 });


### PR DESCRIPTION
first reported here https://github.com/airbnb/rendr/issues/48

allows for the following view/template directory structures

given you have a view named `ConditionsIndexView`, the app will now look for view/template files in the following order relative to the view/template directory.

```
conditions_index_view
conditions/index
conditions/index_view
```

Similarly, if you have a controller named `MyCoolFeatureIndexView`...

```
my_cool_feature_index_view
my_cool_feature/index
my_cool_feature/index_view
my/cool/feature/index
my/cool/feature/index_view
```
