### PR TITLE
Allow view & template subdirs; support default viewPath in controller

### DIFF
--- a/server/router.js
+++ b/server/router.js
@@ -63,21 +63,20 @@ ServerRouter.prototype.getHandler = function(action, pattern, route) {
       }
     };
 
-    action.call(context, params, function(err, template, locals) {
-      var viewData;
+    action.call(context, params, function(err, viewPath, locals) {
+      if (err) return router.handleErr(err, req, res);
 
-      if (err) {
-        return router.handleErr(err, req, res);
-      }
-      viewData = {
-        locals: locals,
+      var defaults = router.defaultHandlerParams(viewPath, locals, route);
+      viewPath = defaults[0], locals = defaults[1];
+
+      var viewData = {
+        locals: locals || {},
         app: app,
         req: req
       };
-      res.render(template, viewData, function(err, html) {
-        if (err) {
-          return router.handleErr(err, req, res);
-        }
+
+      res.render(viewPath, viewData, function(err, html) {
+        if (err) return router.handleErr(err, req, res);
         res.set(router.getHeadersForRoute(route));
         res.type('html').end(html);
       });

--- a/server/viewEngine.js
+++ b/server/viewEngine.js
@@ -1,8 +1,7 @@
 /*global rendr*/
 
-var Handlebars, fs, layoutTemplate, path, _;
+var Handlebars, fs, layoutTemplate, _;
 
-path = require('path');
 fs = require('fs');
 _ = require('underscore');
 Handlebars = require('handlebars');
@@ -57,14 +56,15 @@ function getLayoutTemplate(callback) {
 }
 
 function getViewHtml(viewPath, locals, app) {
-  var BaseView, View, name, view;
+  var BaseView, View, name, view, basePath;
 
+  basePath = 'app/views';
   BaseView = require('../shared/base/view');
   locals = _.clone(locals);
 
   // Pass in the app.
   locals.app = app;
-  name = path.basename(viewPath);
+  name = viewPath.substr(viewPath.indexOf(basePath) + basePath.length + 1);
   View = BaseView.getView(name);
   view = new View(locals);
   return view.getHtml();

--- a/shared/base/router.js
+++ b/shared/base/router.js
@@ -170,6 +170,17 @@ BaseRouter.prototype.parseDefinitions = function(definitions) {
   return route;
 };
 
+/**
+ * Support omitting view path; default it to ":controller/:action".
+ */
+BaseRouter.prototype.defaultHandlerParams = function(viewPath, locals, route) {
+  if (typeof viewPath !== 'string') {
+    locals = viewPath;
+    viewPath = route.controller + '/' + route.action;
+  }
+  return [viewPath, locals];
+};
+
 /*
 * Methods to be extended by subclasses.
 * -------------------------------------


### PR DESCRIPTION
This is a simplified version of @technicolorenvy's #50.  Instead of magically mapping i.e. `home_index_view` to one of `home_index_view`, `home/index_view`, `home/index`, etc., this just supports the explicit use of subdirectories.  In other words, in your controller, you can pass nested paths like `home/index`, and as long as you have a view  `app/views/home/index.js` and a template `app/templates/home/index.hbs`, it will work just fine.

It also requires a view's `id` to match its module path, so a view located at `home/index.js` will look like this:

``` js
var BaseView = require('rendr/shared/base/view');
module.exports = BaseView.extend({
  // ...
});
module.exports.id = 'home/index';
```

This was enabled by a simple change to `viewEngine` to not strip out the basepath of the `viewPath` passed to it.

Additionally, this PR adds the ability to omit the `viewPath` in a controller, supporting the default of i.e. `:controller/:action`.  So, your `users_controller.js` might look like this:

``` js
module.exports = {
  show: function(params, callback) {
    var spec = {
      model: {model: 'User', params: params}
    };
    this.app.fetch(spec, function(err, result) {
      callback(err, result);
    });
  }
};
```

And the router will assume a `viewPath` of `users/show`.  This can save a lot of typing, because typically the view name matches the controller & action.
