### PR TITLE
Save and re-use views from memory store

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -450,8 +450,11 @@ BaseView.attach = function(app, parentView) {
         }
       });
       options.app = app;
-      ViewClass = BaseView.getView(viewName);
-      view = new ViewClass(options);
+      view = app.fetcher.viewStore.get(viewName);
+      if(!view){
+        ViewClass = BaseView.getView(viewName);
+        view = new ViewClass(options);
+      }
       view.attach($el, parentView);
       return view;
     }

--- a/shared/fetcher.js
+++ b/shared/fetcher.js
@@ -33,7 +33,7 @@ and returns an identifying object:
   }
 */
 
-var Backbone, CollectionStore, ModelStore, async, modelUtils, _;
+var Backbone, CollectionStore, ModelStore, ViewStore, async, modelUtils, _;
 
 _ = require('underscore');
 Backbone = require('backbone');
@@ -42,6 +42,7 @@ async = require('async');
 modelUtils = require('./modelUtils');
 ModelStore = require('./store/model_store');
 CollectionStore = require('./store/collection_store');
+ViewStore = require('./store/view_store');
 
 module.exports = Fetcher;
 
@@ -52,6 +53,9 @@ function Fetcher(options) {
     app: this.app
   });
   this.collectionStore = new CollectionStore({
+    app: this.app
+  });
+  this.viewStore = new ViewStore({
     app: this.app
   });
 }

--- a/shared/handlebarsHelpers.js
+++ b/shared/handlebarsHelpers.js
@@ -32,20 +32,25 @@ module.exports = {
       options.parentView = parentView;
     }
 
-    // Tell view not to call postInitialize
-    options.preventPostInitialize = true;
+    // Try to get view stored in app cache
+    if(app){
+      view = app.fetcher.viewStore.get(viewName);
+    }
 
-    // get the Backbone.View based on viewName
-    ViewClass = BaseView.getView(viewName);
-    view = new ViewClass(options);
+    if(!view){
+      // get the Backbone.View based on viewName
+      ViewClass = BaseView.getView(viewName);
+      view = new ViewClass(options);
+      if(app){
+        app.fetcher.viewStore.set(view);
+      }
+    } else {
+    // re-initialize view with new options
+      view.initialize(options);
+    }
 
     // create the outerHTML using className, tagName
     html = view.getHtml();
-
-    // remove view as its parentView will re-create it from data-view attributes present in html
-    if (!global.isServer) {
-      view.remove();
-    }
 
     return new Handlebars.SafeString(html);
   },

--- a/shared/store/view_store.js
+++ b/shared/store/view_store.js
@@ -1,0 +1,44 @@
+var MemoryStore, Super, modelUtils, _;
+
+_ = require('underscore');
+Super = MemoryStore = require('./memory_store');
+modelUtils = require('../modelUtils');
+
+module.exports = ViewStore;
+
+function ViewStore() {
+  Super.apply(this, arguments);
+}
+
+/**
+ * Set up inheritance.
+ */
+ViewStore.prototype = Object.create(Super.prototype);
+ViewStore.prototype.constructor = ViewStore;
+
+ViewStore.prototype.set = function(view) {
+  var key, viewName;
+  viewName = modelUtils.modelName(view.constructor);
+  if (viewName == null) {
+    throw new Error('Undefined viewName for view');
+  }
+  key = getViewStoreKey(viewName);
+  return Super.prototype.set.call(this, key, view, null);
+};
+
+ViewStore.prototype.get = function(viewName) {
+  var key, view;
+  key = getViewStoreKey(viewName);
+  view = Super.prototype.get.call(this, key);
+  if (view) {
+    return view;
+  }
+};
+
+ViewStore.prototype._formatKey = function(key) {
+  return Super.prototype._formatKey.call(this, "_vs:" + key);
+};
+
+function getViewStoreKey(viewName) {
+  return modelUtils.underscorize(viewName);
+}


### PR DESCRIPTION
When view are created via Handlebars view helper, they are added to a memory store like models and collections. Later when BaseView tries to re-attach views to DOM it looks up memory store for the same name view. 
I am not sure if using fetcher to hold viewStore is a good idea as fetcher mainly deals with serializeable data. Any ideas where we could store views?
