### PR TITLE
Allowing the app.postInitialize function acess to app.req object

### DIFF
--- a/server/middleware/initApp.js
+++ b/server/middleware/initApp.js
@@ -21,6 +21,9 @@ module.exports = function(appAttributes) {
     // Hold on to a copy of the original request, so we can pull headers, etc.
     app.req = req;
 
+    // call post initialize after we have req
+    app.postInitialize();
+
     // Stash on the request so can be accessed elsewhere.
     req.rendrApp = app;
 

--- a/shared/app.js
+++ b/shared/app.js
@@ -34,8 +34,8 @@ module.exports = Backbone.Model.extend({
       new ClientRouter({
         app: this
       });
+      this.postInitialize();
     }
-    this.postInitialize();
   },
 
   postInitialize: noop,


### PR DESCRIPTION
This will allow for access to the app.req object server side inside of the app.postInitialize function.

``` javascript
AppBase.extend({
    postInitialize : function(){
       if (global.isServer) {
           if(this.req){
               console.log("we can see the headers")
           }
       }
    }
})
```
