### PR TITLE
Add BaseApp#options and allow accessing Express req in postInitialize()

### DIFF
--- a/server/middleware/initApp.js
+++ b/server/middleware/initApp.js
@@ -1,12 +1,12 @@
 /*global rendr*/
 
 /**
- * We add 'req.rendrApp' so any middleware can access the Rendr
+ * We add `req.rendrApp` so any middleware can access the Rendr
  * app. We need to inject it into views, models, etc., in order
  * to provide user-specific functionality, such as sessions.
  * We can't just access it as a global, because there are concurrent
  * requests for different users.
-*/
+ */
 module.exports = function(appAttributes) {
   appAttributes = appAttributes || {};
   return function(req, res, next) {
@@ -14,14 +14,24 @@ module.exports = function(appAttributes) {
 
     App = require(rendr.entryPath + '/app/app');
 
-    // Pass any config that needs to be accessible by the client
-    // and server into the app.
-    app = new App(appAttributes);
+    /**
+     * Pass any data that needs to be accessible by the client
+     * and server into the app as `appAttributes`.
+     * Pass any non-app-data config using `appOptions`.
+     */
+    var appOptions = {
+      /**
+       * Hold on to a copy of the original request, so we can pull headers, etc.
+       * This will only be accessible on the server.
+       */
+      req: req
+    };
 
-    // Hold on to a copy of the original request, so we can pull headers, etc.
-    app.req = req;
+    app = new App(appAttributes, appOptions);
 
-    // Stash on the request so can be accessed elsewhere.
+    /**
+     * Stash the app instance on the request so can be accessed in other middleware.
+     */
     req.rendrApp = app;
 
     next();

--- a/shared/app.js
+++ b/shared/app.js
@@ -27,16 +27,42 @@ module.exports = Backbone.Model.extend({
   /**
    * @shared
    */
-  initialize: function() {
+  initialize: function(attributes, options) {
+    this.options = options || {};
+
+    /**
+     * On the server-side, you can access the Express request, `req`.
+     */
+    if (this.options.req) {
+      this.req = this.options.req;
+    }
+
+    /**
+     * Initialize the `templateAdapter`, allowing application developers to use whichever
+     * templating system they want.
+     */
     this.templateAdapter = require(this.get('templateAdapter'));
+
+    /**
+     * Instantiate the `Fetcher`, which is used on client and server.
+     */
     this.fetcher = new Fetcher({
       app: this
     });
+
+    /**
+     * Initialize the `ClientRouter` on the client-side.
+     */
     if (!global.isServer) {
       new ClientRouter({
         app: this
       });
     }
+
+    /**
+     * Call `postInitialize()`, to make it easy for an application to easily subclass and add custom
+     * behavior without having to call i.e. `BaseApp.prototype.initialize.apply(this, arguments)`.
+     */
     this.postInitialize();
   },
 


### PR DESCRIPTION
This supercedes https://github.com/airbnb/rendr/pull/79, accomplishing the same thing, but in a way that matches better with the direction Rendr is moving.

Now, a subclass of `BaseApp` can access `this.req` in its `postInitialize()` method.

/cc @jacoblwe20
