### PR TITLE
Better support for multiple models/collections

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -144,7 +144,7 @@ module.exports = BaseView = Backbone.View.extend({
    * Get HTML attributes to add to el.
    */
   getAttributes: function() {
-    var attributes = {};
+    var attributes = {}, fetchSummary = {};
 
     if (this.id) {
       attributes.id = this.id;
@@ -160,28 +160,38 @@ module.exports = BaseView = Backbone.View.extend({
     // Add model & collection meta data from options,
     // as well as any non-object option values.
     _.each(this.options, function(value, key) {
+      var id, modelOrCollectionId;
+
       if (value != null) {
-        if (key === 'model') {
-          key = 'model_id';
-          var id = value[value.idAttribute];
-          if (id == null) {
-            // Bail if there's no ID; someone's using `this.model` in a
-            // non-standard way, and that's okay.
+        if (_.isFunction(value.constructor) && value.constructor.id != null) {
+          modelOrCollectionId = value.constructor.id;
+          if (modelUtils.isModel(value)) {
+            id = value.id;
+            if (id == null) {
+              // Bail if there's no ID; someone's using `this.model` in a
+              // non-standard way, and that's okay.
+              return;
+            }
+            // Cast the `id` attribute to string to ensure it's included in attributes.
+            // On the server, it can be i.e. an `ObjectId` from Mongoose.
+            value = id.toString();
+            fetchSummary[key] = {model: modelOrCollectionId, id: value};
             return;
           }
-          // Cast the `id` attribute to string to ensure it's included in attributes.
-          // On the server, it can be i.e. an `ObjectId` from Mongoose.
-          value = id.toString();
-        } else if (key === 'collection') {
-          key = 'collection_params';
-          value = _.escape(JSON.stringify(value.params));
+          if (modelUtils.isCollection(value) && value.params != null) {
+            fetchSummary[key] = {collection: modelOrCollectionId, params: value.params};
+            return;
+          }
         }
         if (!_.isObject(value) && !_.include(this.nonAttributeOptions, key)) {
-          attributes["data-" + key] = _.escape(value);
+          attributes["data-" + key] = value;
         }
       }
     });
 
+    if (!_.isEmpty(fetchSummary)) {
+      attributes['data-fetch_summary'] = JSON.stringify(fetchSummary);
+    }
     return attributes;
   },
 
@@ -210,7 +220,7 @@ module.exports = BaseView = Backbone.View.extend({
     html = this.getInnerHtml();
     attributes = this.getAttributes();
     attrString = _.inject(attributes, function(memo, value, key) {
-      return memo += " " + key + "=\"" + value + "\"";
+      return memo += " " + key + "=\"" + _.escape(value) + "\"";
     }, '');
     return "<" + this.tagName + attrString + ">" + html + "</" + this.tagName + ">";
   },
@@ -312,19 +322,7 @@ module.exports = BaseView = Backbone.View.extend({
   hydrate: function() {
     var fetchSummary, results;
 
-    fetchSummary = {};
-    if (this.options.model_name != null && this.options.model_id != null) {
-      fetchSummary.model = {
-        model: this.options.model_name,
-        id: this.options.model_id
-      };
-    }
-    if (this.options.collection_name != null && this.options.collection_params != null) {
-      fetchSummary.collection = {
-        collection: this.options.collection_name,
-        params: this.options.collection_params
-      };
-    }
+    fetchSummary = this.options.fetch_summary;
     if (!_.isEmpty(fetchSummary)) {
       results = this.app.fetcher.hydrate(fetchSummary, {
         app: this.app


### PR DESCRIPTION
When a view is rendered on the server-side, the corresponding view of the client-side is able to retrieve just one model or collection.

This patch allows a view to restore multiple models and collections, and it may fix #53.
