### PR TITLE
Delete entity body for some GET requests

### DIFF
--- a/server/data_adapter/rest_adapter.js
+++ b/server/data_adapter/rest_adapter.js
@@ -134,6 +134,12 @@ RestAdapter.prototype.apiDefaults = function(api) {
   if (api.body != null) {
     api.json = api.body;
   }
+  
+  // Remove entity body for GET requests if body is empty object
+  if (api.method === 'GET' && Object.keys(api.body).length === 0){
+    delete api.json;
+    delete api.body;
+  }
 
   return api;
 };


### PR DESCRIPTION
If a GET request includes an entity body that is an empty object, delete it.

Some servers will reject GET requests with an entity body, as it is non-standard. Also, Request automatically adds a content-length header to requests with an entity body, which can cause unpredictable effects.

This change won't affect developers who intentionally include an entity-body, as it only deletes empty objects.

It is possible to implement this using a custom data-adapter, but I think it makes sense for this to be the default behavior, as many servers don't expect an entity body in a GET request.

Fixes #87.
