### PR TITLE
Handle status code 204 properly

### DIFF
--- a/server/middleware/apiProxy.js
+++ b/server/middleware/apiProxy.js
@@ -27,15 +27,10 @@ function apiProxy(apiHostsMap) {
     rendr.server.dataAdapter.request(req, api, {
       convertErrorCode: false
     }, function(err, response, body) {
-      var status;
-
       if (err) return next(err);
 
-      // Pass through statusCode, but not if it's an i.e. 304.
-      status = response.statusCode;
-      if (utils.isErrorStatus(status)) {
-        res.status(status);
-      }
+      // Pass through statusCode.
+      res.status(response.statusCode);
       res.json(body);
     });
   };

--- a/shared/base/collection.js
+++ b/shared/base/collection.js
@@ -67,7 +67,7 @@ module.exports = Super.extend({
     if (modifyInstance == null) {
       modifyInstance = true;
     }
-    if (this.jsonKey && (jsonResp = resp[this.jsonKey])) {
+    if (resp != null && this.jsonKey && (jsonResp = resp[this.jsonKey])) {
       if (modifyInstance) {
         meta = _.omit(resp, this.jsonKey);
         _.extend(this.meta, meta);

--- a/shared/base/model.js
+++ b/shared/base/model.js
@@ -28,7 +28,7 @@ module.exports = Super.extend({
    * Idempotent parse
    */
   parse: function(resp) {
-    if (this.jsonKey) {
+    if (resp != null && this.jsonKey) {
       return resp[this.jsonKey] || resp;
     } else {
       return resp;


### PR DESCRIPTION
An API server may return "204 No Content" for PUT or DELETE request, but apiProxy ignores it and returns "200 OK" on the server side. Then, on the client side, jQuery detects "parseerror" because the response has no body.

This patch makes apiProxy handling status code 204 properly.
And also, it converts status 304 into 500, because a valid API server never returns it (because apiProxy doesn't send cache related headers such as "If-Modified-Since:".).
