### PR TITLE
Use id property when fetching Model#id

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -163,7 +163,7 @@ module.exports = BaseView = Backbone.View.extend({
       if (value != null) {
         if (key === 'model') {
           key = 'model_id';
-          var id = value[value.idAttribute];
+          var id = value.id;
           if (id == null) {
             // Bail if there's no ID; someone's using `this.model` in a
             // non-standard way, and that's okay.


### PR DESCRIPTION
Using the bracket syntax is discouraged for fetching ids. The id is copied directly as a property to the model.

http://backbonejs.org/#Model-id

I had issues when using their example of:

``` js
var Meal = Backbone.Model.extend({
  idAttribute: "_id"
});
```

I ran the test suite and it passed for me.
