### PR TITLE
Use id accessor when fetching Model#id

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -163,7 +163,7 @@ module.exports = BaseView = Backbone.View.extend({
       if (value != null) {
         if (key === 'model') {
           key = 'model_id';
-          var id = value[value.idAttribute];
+          var id = value.id;
           if (id == null) {
             // Bail if there's no ID; someone's using `this.model` in a
             // non-standard way, and that's okay.


### PR DESCRIPTION
I was having difficulty with Backbone's model example:

``` javascript
var Meal = Backbone.Model.extend({
  idAttribute: "_id"
});
```

I believe this fixes it. I ran the test suite and it passed.

It would also work with the `.get` syntax, if you prefer that.
