### PR TITLE
Storing collections params along with ids and meta.

### DIFF
--- a/shared/fetcher.js
+++ b/shared/fetcher.js
@@ -153,7 +153,8 @@ Fetcher.prototype._retrieve = function(fetchSpecs, options, callback) {
           if (collectionData) {
             modelData = this.retrieveModelsForCollectionName(spec.collection, collectionData.ids);
             modelOptions = {
-              meta: collectionData.meta
+              meta: collectionData.meta,
+              params: collectionData.params
             };
           }
         }

--- a/shared/store/collection_store.js
+++ b/shared/store/collection_store.js
@@ -23,7 +23,8 @@ CollectionStore.prototype.set = function(collection, params) {
   idAttribute = collection.model.prototype.idAttribute;
   data = {
     ids: collection.pluck(idAttribute),
-    meta: collection.meta
+    meta: collection.meta,
+    params: collection.params
   };
   return Super.prototype.set.call(this, key, data, null);
 };

--- a/test/shared/fetcher.test.js
+++ b/test/shared/fetcher.test.js
@@ -178,7 +178,8 @@ describe('fetcher', function() {
       should.not.exist(fetcher.collectionStore.get('Listings', {}));
       fetcher.collectionStore.get('Listings', params).should.eql({
         ids: listings.pluck('id'),
-        meta: {}
+        meta: {},
+        params: params
       });
     });
 

--- a/test/shared/store/collection_store.test.js
+++ b/test/shared/store/collection_store.test.js
@@ -41,7 +41,8 @@ describe('CollectionStore', function() {
     results = this.store.get(collection.constructor.name, params);
     results.should.eql({
       ids: collection.pluck('id'),
-      meta: meta
+      meta: meta,
+      params: params
     });
   });
 
@@ -87,7 +88,8 @@ describe('CollectionStore', function() {
     results = this.store.get(collection.constructor.name, params);
     results.should.eql({
       ids: collection.pluck('login'),
-      meta: meta
+      meta: meta,
+      params: params
     });
   });
 
@@ -123,12 +125,14 @@ describe('CollectionStore', function() {
     results0 = this.store.get(collection0.constructor.name, params0);
     results0.should.eql({
       ids: collection0.pluck('id'),
-      meta: {}
+      meta: {},
+      params: params0
     });
     results10 = this.store.get(collection10.constructor.name, params10);
     results10.should.eql({
       ids: collection10.pluck('id'),
-      meta: {}
+      meta: {},
+      params: params10
     });
   });
 


### PR DESCRIPTION
This allows for the collections to be rebuilt using the same params.

Steps to reproduce:
1) navigate to page with collection.
collection accurately has the spec params associated
2) navigate away.
3) navigate to initial page.
collection does not have the params originally set.

`npm test` passes for me.
