### PR TITLE
Added very basic client error handler. And basic test.

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -207,8 +207,14 @@ ClientRouter.prototype.redirectTo = function(path, options) {
   }
 };
 
+ClientRouter.prototype.handleErr = function(err, route){
+  this.trigger('action:error', err, route);
+}
+
 ClientRouter.prototype.getRenderCallback = function(route) {
   return function(err, viewPath, locals) {
+    if (err) return this.handleErr(err, route);
+
     var View;
 
     if (this.currentView) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "mocha": "*",
     "should": "*",
     "sinon": "1.4.2",
-    "istanbul": "~0.1.10"
+    "istanbul": "~0.1.10",
+    "jquery": "~1.8.3"
   },
   "keywords": [
     "Backbone",

--- a/test/client/router.test.js
+++ b/test/client/router.test.js
@@ -1,0 +1,54 @@
+var App, Backbone, BaseView, Router, should, sinon, routerConfig;
+
+Backbone = require('backbone');
+should = require('should');
+sinon = require('sinon');
+
+App = require('../../shared/app');
+BaseView = require('../../shared/base/view');
+Router = require('../../client/router');
+
+// This should go in a global setup.
+// it sets a global $ variable, which is accessed in AppView;
+Backbone.$ = global.$ = require('jquery').create();
+
+routerConfig = {
+  app: new App,
+  paths: {
+    entryPath: __dirname + "/../fixtures"
+  }
+};
+
+describe("client/router", function() {
+
+  // Since this is simulating the client, we need to find the elements in the jsdom
+  before(function(){
+    this.originalEnsure = BaseView.prototype._ensureElement;
+    this.originalDelegate = BaseView.prototype.delegateEvents;
+    BaseView.prototype._ensureElement = Backbone.View.prototype._ensureElement;
+    BaseView.prototype.delegateEvents = Backbone.View.prototype.delegateEvents;
+  });
+
+  after(function(){
+    BaseView.prototype._ensureElement = this.originalEnsure;
+    BaseView.prototype.delegateEvents = this.originalDelegate;
+  });
+
+  beforeEach(function() {
+    this.router = new Router(routerConfig);
+  });
+
+  describe('getRenderCallback', function(){
+    it("should trigger a router:error on the application", function(done) {
+      this.router.on("action:error", function(err, route){
+        err.should.have.property('status', 401);
+        route.should.equal("myRoute")
+        done();
+      });
+
+      var routeCallback = this.router.getRenderCallback("myRoute");
+      routeCallback({status: 401}, null, null);
+    });
+  });
+
+});


### PR DESCRIPTION
The problem is that the server and client handle errors differently. The server has an errorHandler which is passed in as the initialization options, but the client does not. This pull request begins to address this issue.

Example usage:

``` javascript
// Rendr controller:
function(params, callback){
  if (!params.specialValue)
    return callback(status: 404);
  callback(null, params.specialValue);
}
```

This above code works when rendered by the server using example rendr-app-template errorHandler: https://github.com/airbnb/rendr-app-template/blob/a630de5fa838975cd11094aded49a433fa0990e8/server/middleware/errorHandler.js

This pull request just adds basic functionality, it would probably be better to push a user defined errorHandler to the client, similar to the server initialization. But this allows the controller to send the user to a 404 of 500 (or other status code) page.

The test setup was kinda crazy. It's expecting a DOM and jQuery and elements and such for the AppView, so I had to sorta fudge my way around. But `npm test` does pass. If you guys have a better way to test the client code, by all means please change it.

Thanks!
