### PR TITLE
Updates to server based on real-world usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ if (!this.window) {
 
   exports.server = null;
 
-  exports.createServer = function(expressApp, options) {
-    return exports.server = new Server(expressApp, options);
+  exports.createServer = function(options) {
+    return exports.server = new Server(options);
   };
 
   exports.entryPath = process.cwd();

--- a/server/middleware/initApp.js
+++ b/server/middleware/initApp.js
@@ -8,11 +8,8 @@
  * requests for different users.
  */
 module.exports = function(appAttributes) {
-  appAttributes = appAttributes || {};
   return function(req, res, next) {
-    var App, app;
-
-    App = require(rendr.entryPath + '/app/app');
+    var App = require(rendr.entryPath + '/app/app');
 
     /**
      * Pass any data that needs to be accessible by the client
@@ -27,7 +24,17 @@ module.exports = function(appAttributes) {
       req: req
     };
 
-    app = new App(appAttributes, appOptions);
+    /**
+     * Allow `appAttributes` to be a function for lazy-instantiation based on `req` and `res`.
+     */
+    function getAppAttributes(attrs, req, res) {
+      if (typeof attrs === 'function') {
+        attrs = attrs(req, res);
+      }
+      return attrs || {};
+    }
+
+    var app = new App(getAppAttributes(appAttributes, req, res), appOptions);
 
     /**
      * Stash the app instance on the request so can be accessed in other middleware.

--- a/shared/syncer.js
+++ b/shared/syncer.js
@@ -1,27 +1,25 @@
-var Backbone, extractParamNamesRe, methodMap, modelUtils, qs, _, syncer;
+var _ = require('underscore')
+  , Backbone = require('backbone')
+
+  // These are lazy-required.
+  , modelUtils = null
+  , server = null
+
+  // Pull out params in path, like '/users/:id'.
+  , extractParamNamesRe = /:([a-z_-]+)/ig
+
+  , methodMap = {
+    'create': 'POST',
+    'update': 'PUT',
+    'delete': 'DELETE',
+    'read': 'GET'
+  };
 
 if (global.isServer) {
-  qs = require('qs');
+  var qs = require('qs');
 }
 
-_ = require('underscore');
-Backbone = require('backbone');
-
-// These are lazy-required.
-modelUtils = null;
-server = null;
-
-// Pull out params in path, like '/users/:id'.
-extractParamNamesRe = /:([a-zA-Z_-]+)/g;
-
-methodMap = {
-  'create': 'POST',
-  'update': 'PUT',
-  'delete': 'DELETE',
-  'read': 'GET'
-};
-
-syncer = module.exports;
+var syncer = module.exports;
 
 function clientSync(method, model, options) {
   var data;
@@ -142,8 +140,7 @@ syncer.formatClientUrl = function(url, api) {
  * Happens only client-side.
  */
 syncer.checkFresh = function checkFresh() {
-  var url,
-    _this = this;
+  var url;
 
   this.app.trigger('checkFresh:start');
 
@@ -155,25 +152,25 @@ syncer.checkFresh = function checkFresh() {
     var data, differs;
 
     // The second argument 'false' tells 'parse()' not to modify the instance.
-    data = _this.parse(resp, false);
-    differs = syncer.objectsDiffer(data, _this.toJSON());
-    _this.trigger('checkFresh:end', differs);
+    data = this.parse(resp, false);
+    differs = syncer.objectsDiffer(data, this.toJSON());
+    this.trigger('checkFresh:end', differs);
     if (differs) {
-      if (modelUtils.isModel(_this)) {
-        _this.set(data, {
+      if (modelUtils.isModel(this)) {
+        this.set(data, {
           silent: true
         });
       } else {
-        _this.reset(data, {
+        this.reset(data, {
           parse: true,
           silent: true
         });
       }
       // We manually store the updated data.
-      _this.store();
-      _this.trigger('refresh');
+      this.store();
+      this.trigger('refresh');
     }
-  });
+  }.bind(this));
 };
 
 /**


### PR DESCRIPTION
This branch contains a number of fixes that make the new, easier way of
setting up a Rendr app work for more complex apps. This was tested
against one of the more complex Airbnb apps.

Some specific changes:
- Add a `viewsPath` server option.
- Allow `appAttributes` server option to be a `function` that takes
  `(req, res)`, to support dynamic app attributes that depend on the
  `req` or `res`.
- Add back the `notFoundHandler` server option.
- Add `server.handle` middlewqre handler, which allows mounting the
  server directly as an Express middleware, i.e. `app.use(server)`.
- Format `syncer` for style.
