### PR TITLE
Never reference rendr.server as a global

### DIFF
--- a/server/middleware/apiProxy.js
+++ b/server/middleware/apiProxy.js
@@ -12,7 +12,7 @@ var separator = '/-/';
  */
 module.exports = apiProxy;
 
-function apiProxy() {
+function apiProxy(dataAdapter) {
   return function(req, res, next) {
     var api;
 
@@ -21,7 +21,7 @@ function apiProxy() {
     api.path = apiProxy.getApiPath(req.path);
     api.api = apiProxy.getApiName(req.path);
 
-    rendr.server.dataAdapter.request(req, api, {
+    dataAdapter.request(req, api, {
       convertErrorCode: false
     }, function(err, response, body) {
       if (err) return next(err);

--- a/shared/syncer.js
+++ b/shared/syncer.js
@@ -32,13 +32,14 @@ function clientSync(method, model, options) {
 }
 
 function serverSync(method, model, options) {
-  var api, data, urlParts, verb;
+  var api, data, urlParts, verb, req;
 
   data = _.clone(options.data);
   data = addApiParams(method, model, data);
   options.url = this.getUrl(options.url, false, data);
   verb = methodMap[method];
   urlParts = options.url.split('?');
+  req = this.app.req;
 
   api = {
     method: verb,
@@ -58,7 +59,7 @@ function serverSync(method, model, options) {
     _.extend(api.query, data);
   }
 
-  rendr.server.dataAdapter.request(this.app.req, api, function(err, response, body) {
+  req.dataAdapter.request(req, api, function(err, response, body) {
     if (err) {
       if (!_.isObject(body)) {
         body = {


### PR DESCRIPTION
To enable this, we inject `dataAdapter` into the `apiProxy`
middleware, and also we attach `dataAdapter` to `req`, so that the
`syncer` can access. It would be nice to find an alternative to this, so
we don't bloat the `req`.

This is a necessary step towards enabling developers to run multiple
Rendr apps in the same Express app, which can be useful.
