### PR TITLE
Remove unnecessary use of `bind` in router

### DIFF
--- a/shared/base/router.js
+++ b/shared/base/router.js
@@ -13,7 +13,6 @@ module.exports = BaseRouter;
  * Base router class shared betwen ClientRouter and ServerRouter.
  */
 function BaseRouter(options) {
-  this.route = this.route.bind(this);
   this._routes = [];
   this._initOptions(options);
   this.initialize(options);


### PR DESCRIPTION
Try to fix #121 by simply not using `bind`. Where `this.route` is
actually called, `apply` is used to set the context anyway, so this line
should be unnecessary.
