### PR TITLE
Refactor `syncer` into mixin for `BaseCollection`, `BaseModel`

### DIFF
--- a/shared/base/collection.js
+++ b/shared/base/collection.js
@@ -1,13 +1,10 @@
-var Backbone, BaseModel, syncer, _, Super;
+var _ = require('underscore')
+  , Backbone = require('backbone')
+  , syncer = require('../syncer')
+  , BaseModel = require('./model')
+  , Super = Backbone.Collection;
 
-_ = require('underscore');
-Backbone = require('backbone');
-syncer = require('../syncer');
-BaseModel = require('./model');
-
-Super = Backbone.Collection;
-
-module.exports = Super.extend({
+BaseCollection = Super.extend({
 
   model: BaseModel,
 
@@ -43,8 +40,6 @@ module.exports = Super.extend({
       _.extend(this.meta, this.options.meta);
       delete this.options.meta;
     }
-
-    Super.prototype.initialize.apply(this, arguments);
   },
 
   /**
@@ -103,14 +98,6 @@ module.exports = Super.extend({
     return Super.prototype.fetch.apply(this, arguments);
   },
 
-  lastCheckedFresh: null,
-
-  checkFresh: syncer.checkFresh,
-
-  sync: syncer.getSync(),
-
-  getUrl: syncer.getUrl,
-
   /**
    * Instance method to store the collection and its models.
    */
@@ -121,3 +108,11 @@ module.exports = Super.extend({
     this.app.fetcher.collectionStore.set(this);
   }
 });
+
+/**
+ * Mix-in the `syncer`, shared between `BaseModel` and `BaseCollection`, which
+ * encapsulates logic for fetching data from the API.
+ */
+_.extend(BaseCollection.prototype, syncer);
+
+module.exports = BaseCollection;

--- a/shared/base/model.js
+++ b/shared/base/model.js
@@ -1,12 +1,8 @@
-var _, Backbone, syncer, Super;
+var _ = require('underscore')
+  , Backbone = require('backbone')
+  , syncer = require('../syncer');
 
-_ = require('underscore');
-Backbone = require('backbone');
-syncer = require('../syncer');
-
-Super = Backbone.Model;
-
-module.exports = Super.extend({
+var BaseModel = Backbone.Model.extend({
 
   initialize: function(models, options) {
     // Capture the options as instance variable.
@@ -20,8 +16,6 @@ module.exports = Super.extend({
     }
 
     this.on('change', this.store, this);
-
-    Super.prototype.initialize.apply(this, arguments);
   },
 
   /**
@@ -35,12 +29,6 @@ module.exports = Super.extend({
     }
   },
 
-  checkFresh: syncer.checkFresh,
-
-  sync: syncer.getSync(),
-
-  getUrl: syncer.getUrl,
-
   /**
    * Instance method to store in the modelStore.
    */
@@ -48,3 +36,11 @@ module.exports = Super.extend({
     this.app.fetcher.modelStore.set(this);
   }
 });
+
+/**
+ * Mix-in the `syncer`, shared between `BaseModel` and `BaseCollection`, which
+ * encapsulates logic for fetching data from the API.
+ */
+_.extend(BaseModel.prototype, syncer);
+
+module.exports = BaseModel;


### PR DESCRIPTION
This will make it easier to extend the functionality of `BaseModel` and
`BaseCollection`, and to do things like access properties of the `app`
in the various methods.

Also refactored for style a bit.  There was some remnants of the CoffeeScript compiled code.
