### PR TITLE
Better handling of error in Fetcher

### DIFF
--- a/shared/fetcher.js
+++ b/shared/fetcher.js
@@ -217,12 +217,15 @@ Fetcher.prototype.fetchFromApi = function(spec, callback) {
     success: function(model, body) {
       callback(null, model);
     },
-    error: function(model, body, options) {
-      var bodyOutput, err;
+    error: function(model, resp, options) {
+      var body, respOutput, err;
 
-      bodyOutput = typeof body === 'string' ? body.slice(0, 150) : JSON.stringify(body);
-      err = new Error("ERROR fetching model '" + modelUtils.modelName(model.constructor) + "' with options '" + JSON.stringify(options) + "'. Response: " + bodyOutput);
-      err.status = body.status;
+      body = resp.body;
+      resp.body = typeof body === 'string' ? body.slice(0, 150) : body;
+      respOutput = JSON.stringify(resp);
+      err = new Error("ERROR fetching model '" + modelUtils.modelName(model.constructor) + "' with options '" + JSON.stringify(options) + "'. Response: " + respOutput);
+      err.status = resp.status;
+      err.body = body;
       callback(err);
     }
   });


### PR DESCRIPTION
`Fetcher.fetchFromApi()` provides error handler for Backbone's `Model.fetch()`, and it expects a response body as a 2nd argument. However, on the client-side, it is an XHR object.

This patch fixes it, and adds a response body to an Error object, because it may be helpful when Controllers decide a navigation.
