### PR TITLE
Fix JS exception in IE due to router inheritance

### DIFF
--- a/examples/00_simple/app/router.js
+++ b/examples/00_simple/app/router.js
@@ -4,7 +4,11 @@ var Router = module.exports = function Router(options) {
   BaseClientRouter.call(this, options);
 };
 
-Router.prototype.__proto__ = BaseClientRouter.prototype;
+/**
+ * Set up inheritance.
+ */
+Router.prototype = Object.create(BaseClientRouter.prototype);
+Router.prototype.constructor = BaseClientRouter;
 
 Router.prototype.postInitialize = function() {
   this.on('action:start', this.trackImpression, this);

--- a/examples/01_config/app/router.js
+++ b/examples/01_config/app/router.js
@@ -4,7 +4,11 @@ var Router = module.exports = function Router(options) {
   BaseClientRouter.call(this, options);
 };
 
-Router.prototype.__proto__ = BaseClientRouter.prototype;
+/**
+ * Set up inheritance.
+ */
+Router.prototype = Object.create(BaseClientRouter.prototype);
+Router.prototype.constructor = BaseClientRouter;
 
 Router.prototype.postInitialize = function() {
   this.on('action:start', this.trackImpression, this);

--- a/examples/02_middleware/app/router.js
+++ b/examples/02_middleware/app/router.js
@@ -4,7 +4,11 @@ var Router = module.exports = function Router(options) {
   BaseClientRouter.call(this, options);
 };
 
-Router.prototype.__proto__ = BaseClientRouter.prototype;
+/**
+ * Set up inheritance.
+ */
+Router.prototype = Object.create(BaseClientRouter.prototype);
+Router.prototype.constructor = BaseClientRouter;
 
 Router.prototype.postInitialize = function() {
   this.on('action:start', this.trackImpression, this);

--- a/examples/03_sessions/app/router.js
+++ b/examples/03_sessions/app/router.js
@@ -4,7 +4,11 @@ var Router = module.exports = function Router(options) {
   BaseClientRouter.call(this, options);
 };
 
-Router.prototype.__proto__ = BaseClientRouter.prototype;
+/**
+ * Set up inheritance.
+ */
+Router.prototype = Object.create(BaseClientRouter.prototype);
+Router.prototype.constructor = BaseClientRouter;
 
 Router.prototype.postInitialize = function() {
   this.on('action:start', this.trackImpression, this);

--- a/examples/04_entrypath/apps/main/app/router.js
+++ b/examples/04_entrypath/apps/main/app/router.js
@@ -4,7 +4,11 @@ var Router = module.exports = function Router(options) {
   BaseClientRouter.call(this, options);
 };
 
-Router.prototype.__proto__ = BaseClientRouter.prototype;
+/**
+ * Set up inheritance.
+ */
+Router.prototype = Object.create(BaseClientRouter.prototype);
+Router.prototype.constructor = BaseClientRouter;
 
 Router.prototype.postInitialize = function() {
   this.on('action:start', this.trackImpression, this);


### PR DESCRIPTION
This should fix #121. In IE, there was a JS error thrown by the
`BaseRouter`'s constructor. It turns out it's just an issue with the way
the example app sets up prototypical inheritance -- IE doesn't support
setting `Router.prototype.__proto__ = BaseClientRouter.prototype`, so we
use `Object.create()` instead, which works in IE due to the polyfill
provided by `es5shim`/`es5sham`.

This same change was made for `airbnb/rendr-app-template` 21 days ago (https://github.com/airbnb/rendr-app-template/commit/cfee163a1c873758e7b148a3629d035031b47399) however it never made in into the examples in this repo.
