### PR TITLE
ModelStore.find

### DIFF
--- a/shared/store/memory_store.js
+++ b/shared/store/memory_store.js
@@ -9,12 +9,13 @@ function MemoryStore(options) {
 MemoryStore.prototype.cacheVersion = '';
 
 MemoryStore.prototype.get = function(key) {
-  var data;
-
   if (!key) {
     return;
   }
-  data = this._get(key);
+  return this.validateExpiration(key, this._get(key));
+};
+
+MemoryStore.prototype.validateExpiration = function(key, data){
   if (data && data.expires && Date.now() > data.expires) {
     if (typeof console !== "undefined") {
       console.log("MemoryStore: Expiring key \"" + key + "\".");

--- a/test/shared/fetcher.test.js
+++ b/test/shared/fetcher.test.js
@@ -362,6 +362,36 @@ describe('fetcher', function() {
       });
     });
 
+    it("should be able to fetch a model from cache with other attributes", function(done) {
+      var fetchSpec;
+      var listingAttrs = {
+        id: 'myId',
+        name: 'New Name'
+      };
+      listingWithName = new Listing(listingAttrs);
+      fetcher.modelStore.set(listingWithName);
+
+      fetchSpec = {
+        model: {
+          model: 'Listing',
+          params: {
+            name: 'New Name'
+          }
+        }
+      };
+      fetcher.pendingFetches.should.eql(0);
+      fetcher.fetch(fetchSpec, {readFromCache: true}, function(err, results) {
+        fetcher.pendingFetches.should.eql(0);
+        if (err) return done(err);
+        results.model.should.be.an.instanceOf(Listing);
+        results.model.toJSON().should.eql(listingAttrs);
+        done();
+      });
+      fetcher.pendingFetches.should.eql(0);
+
+    });
+
+
     it("should be able to re-fetch if already exists but is missing key", function(done) {
       // First, fetch the collection, which has smaller versions of the models.
       var fetchSpec;

--- a/test/shared/store/model_store.test.js
+++ b/test/shared/store/model_store.test.js
@@ -93,4 +93,36 @@ describe('ModelStore', function() {
     result = this.store.get('my_model', 1);
     result.should.eql(finalModelAttrs);
   });
+  describe('find', function(){
+    function MySecondModel() {
+      MySecondModel.super_.apply(this, arguments);
+    }
+    util.inherits(MySecondModel, BaseModel);
+
+    modelUtils.addClassMapping(modelUtils.modelName(MySecondModel), MySecondModel);
+
+    it('should find a model on custom attributes', function(){
+      var model, modelAttrs, result;
+      modelAttrs = {
+        foo: 'bar',
+        id: 1
+      };
+      model = new MyModel(modelAttrs);
+      this.store.set(model);
+      result = this.store.find('my_model', {foo: 'bar'});
+      result.should.eql(modelAttrs);
+    });
+
+    it('should skip different models, even when they match the query', function(){
+      var model, modelAttrs, result;
+      modelAttrs = {
+        foo: 'bar',
+        id: 1
+      };
+      model = new MySecondModel(modelAttrs);
+      this.store.set(model);
+      result = this.store.find('my_model', {foo: 'bar'});
+      should.strictEqual(undefined, result);
+    });
+  });
 });


### PR DESCRIPTION
Hey AirBnB, it's me again. 

The problem is this:

If I have a fetch spec that looks like:

``` js
spec = {model: {model: 'Artist', params: {id: params.id}}}
```

I'm good to go. The fetcher will read and write from cache no problem. Even if I use a different idAttribute.

However let's say my fetch spec looks like:

``` js
spec = {model: {model: 'Artist', params: {name: 'Pendulum'}}}
```

The fetcher does not know how to read and write this spec to cache. 

In my opinion, it's highly unlikely that the database will ever return a different object, considering it's returning just a single model. If I was expecting a different object, I'd either put a cache time in (supported in MemoryStore), or set "readFromCache" or "writeToCache" to false in the fetch options.

This allows the fetcher to search models based on any arbitrary data.

I hope this makes sense. If so, please enjoy this photo of two guinea pigs wearing hats sitting in a tiny hammock.
![Guinea Pigs Wearing Hats](http://4.bp.blogspot.com/_oJpV6yalpOk/TQioeS6UWiI/AAAAAAAAATY/d-gMnfFpi1Y/s1600/The-best-top-desktop-guinea-pig-wallpapers-3.jpg)
