### PR TITLE
Allow redirects with 301 status code

### DIFF
--- a/server/router.js
+++ b/server/router.js
@@ -63,7 +63,14 @@ ServerRouter.prototype.getHandler = function(action, pattern, route) {
     context = {
       currentRoute: route,
       app: app,
-      redirectTo: res.redirect.bind(res)
+      redirectTo: function(uri, options) {
+        if (options !== undefined && options.status) {
+          res.redirect(options.status, uri);
+        }
+        else {
+          res.redirect(uri);
+        }
+      }
     };
 
     action.call(context, params, function(err, viewPath, locals) {

--- a/test/server/router.test.js
+++ b/test/server/router.test.js
@@ -359,7 +359,7 @@ describe("server/router", function() {
             handler;
 
           handler = this.router.getHandler(function () {
-            this.redirectTo(301, '/some_uri');
+            this.redirectTo('/some_uri', {status: 301});
           }, this.pattern, rendrRoute);
 
           handler(this.req, res);


### PR DESCRIPTION
When using the redirectTo method from a controller there is no option to change the http status code (it will always be 302).

Additionally to the two tests that now test the redirect functionality, I added another one testing the getHandler method.
