### PR TITLE
use next() to report error instead of manual call

### DIFF
--- a/server/router.js
+++ b/server/router.js
@@ -69,7 +69,7 @@ ServerRouter.prototype.getHandler = function(action, pattern, route) {
     };
 
     action.call(context, params, function(err, viewPath, locals) {
-      if (err) return router.handleErr(err, req, next);
+      if (err) return next(err);
 
       var defaults = router.defaultHandlerParams(viewPath, locals, route);
       viewPath = defaults[0], locals = defaults[1];
@@ -81,7 +81,7 @@ ServerRouter.prototype.getHandler = function(action, pattern, route) {
       };
 
       res.render(viewPath, viewData, function(err, html) {
-        if (err) return router.handleErr(err, req, next);
+        if (err) return next(err);
         res.set(router.getHeadersForRoute(route));
         res.type('html').end(html);
       });
@@ -96,30 +96,12 @@ ServerRouter.prototype.addExpressRoute = function(routeObj) {
   this._expressRouter.route('get', path, []);
 };
 
-/**
- * Handle an error that happens while executing an action.
- * Could happen during the controller action, view rendering, etc.
- */
-ServerRouter.prototype.handleErr = function(err, req, next) {
-  this.stashError(req, err);
-  next(err);
-};
-
 ServerRouter.prototype.getHeadersForRoute = function(definition) {
   var headers = {};
   if (definition.maxAge != null) {
     headers['Cache-Control'] = "public, max-age=" + definition.maxAge;
   }
   return headers;
-};
-
-/**
- * stash error, if handler available
- */
-ServerRouter.prototype.stashError = function(req, err) {
-  if (this.options.stashError != null) {
-    this.options.stashError(req, err);
-  }
 };
 
 /**

--- a/server/server.js
+++ b/server/server.js
@@ -15,7 +15,6 @@ var defaultOptions = {
   viewEngine: null,
   errorHandler: null,
   notFoundHandler: null,
-  stashError: null,
   apiPath: '/api',
   appData: {},
   paths: {},

--- a/shared/base/router.js
+++ b/shared/base/router.js
@@ -26,7 +26,6 @@ function BaseRouter(options) {
  *     - entryPath (required)
  *     - routes (optional)
  *     - controllerDir (optional)
- *   - stashError: optional function to notify server of error
  */
 BaseRouter.prototype.options = null;
 


### PR DESCRIPTION
We stumbled over this while investigating senchalabs/connect#949: We have a middleware that tries to set a header, which throws an exception because of said issue in connect. While I don't fully understand why, the manual call to the errorHandler (instead of using it as a middleware) causes the server to crash in this case. By replacing the manual call with `next(err)` we can get both rid of this crash and only specify the `errorHandler` in [one place](https://github.com/airbnb/rendr/blob/master/server/server.js#L120) now.
