### PR TITLE
Enable all HTTP Verbs

### DIFF
--- a/server/router.js
+++ b/server/router.js
@@ -98,7 +98,7 @@ ServerRouter.prototype.addExpressRoute = function(routeObj) {
   var path = routeObj[0];
 
   this.routesByPath[path] = routeObj;
-  this._expressRouter.route('get', path, []);
+  this._expressRouter.route('all', path, []);
 };
 
 ServerRouter.prototype.getHeadersForRoute = function(definition) {
@@ -126,6 +126,6 @@ ServerRouter.prototype.match = function(pathToMatch) {
     pathToMatch = '/' + pathToMatch;
   }
 
-  matchedRoute = this._expressRouter.match('get', pathToMatch);
+  matchedRoute = this._expressRouter.match('all', pathToMatch);
   return matchedRoute ? this.routesByPath[matchedRoute.path] : null;
 };

--- a/server/server.js
+++ b/server/server.js
@@ -29,7 +29,7 @@ function Server(options) {
 
   this.expressApp = express();
 
-  this.dataAdapter = this.options.dataAdapter || new RestAdapter(this.options.dataAdapterConfig);;
+  this.dataAdapter = this.options.dataAdapter || new RestAdapter(this.options.dataAdapterConfig);
 
   this.viewEngine = this.options.viewEngine || new ViewEngine();
 
@@ -136,6 +136,6 @@ Server.prototype.buildRoutes = function() {
     handler = args[2];
 
     // Attach the route to the Express server.
-    this.expressApp.get(pattern, handler);
+    this.expressApp.all(pattern, handler);
   }, this);
 };


### PR DESCRIPTION
This changes lets the express server handle POST, PUT, DELETE, UPDATE, etc.  Currently Express will 404 whenever those are attempted as express includes the http verb in it's route matching logic (backbone couldn't care less).

A more specific option here is to enrich the routes.js file to include the verb along with the path and the controller and the action, though it starts to enforce a bit more structure on the routes.js than the current free form structure (could use a default of GET if no verb is specified, so not a breaking change). Wasn't sure what would be preferred, I'm torn on whether the wildcard has any real downsides, happy to implement either way. If you prefer the latter route, I'll add tests too.
