### PR TITLE
make rendr-handlebars a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "sinon": "1.4.2",
     "istanbul": "~0.1.10",
     "jquery": "~1.8.3",
-    "rendr-handlebars": "0.0.8",
+    "rendr-handlebars": "0.0.8"
   },
   "keywords": [
     "Backbone",


### PR DESCRIPTION
the rendr-handlebars module is only required for running the tests.
