### PR TITLE
Reenable View.attributes from Backbone

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -151,6 +151,9 @@ module.exports = BaseView = Backbone.View.extend({
   getAttributes: function() {
     var attributes = {}, fetchSummary = {};
 
+    if (this.attributes) {
+      _.extend(attributes, _.result(this, 'attributes'));
+    }
     if (this.id) {
       attributes.id = this.id;
     }

--- a/test/shared/base/view.test.js
+++ b/test/shared/base/view.test.js
@@ -52,6 +52,62 @@ describe('BaseView', function() {
     });
   });
 
+  describe('getAttributes', function () {
+    beforeEach(function () {
+      this.View = BaseView.extend({
+        id: 'aViewId',
+        className: 'aClassName',
+        name: 'A View Name'
+      });
+    });
+
+    it('should handle view.attributes being non-existant', function () {
+      var view = new this.View();
+
+      view.getAttributes().should.deep.equal({
+        id: 'aViewId',
+        'class': 'aClassName',
+        'data-view': 'A View Name'
+      });
+    });
+
+    it('should handle view.attributes being an object', function () {
+      var view = new this.View();
+
+      view.attributes = {
+        attribute1: 'value1',
+        attribute2: 'value2'
+      };
+
+      view.getAttributes().should.deep.equal({
+        id: 'aViewId',
+        'class': 'aClassName',
+        'data-view': 'A View Name',
+        attribute1: 'value1',
+        attribute2: 'value2'
+      });
+    });
+
+    it('should handle view.attributes being a function', function () {
+      var view = new this.View();
+
+      view.attributes = function () {
+        return {
+          attribute1: 'value1',
+          attribute2: 'value2'
+        };
+      };
+
+      view.getAttributes().should.deep.equal({
+        id: 'aViewId',
+        'class': 'aClassName',
+        'data-view': 'A View Name',
+        attribute1: 'value1',
+        attribute2: 'value2'
+      });
+    });
+  });
+
   describe('_fetchLazyCallback', function() {
     beforeEach(function() {
       this.app = {


### PR DESCRIPTION
Backbone allowed the user to specify View.attributes either as an object or as a method that returns a object. These attributes then get set on the view element (just like the attributes from getAttributes in Rendr). This is functionality that got lost in Rendr and that want to reimplement to remove workarounds like:

``` javascript
var View = BaseView.extend({
    getAttributes: function () {
        return _.extend(BaseView.prototype.getAttributes.apply(this, arguments), this.attributes);
    }
});
```
