### PR TITLE
don't call toJSON on models and collections

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -99,10 +99,10 @@ module.exports = BaseView = Backbone.View.extend({
    */
   getTemplateData: function() {
     if (this.model) {
-      return this.model.toJSON();
+      return this.model;
     } else if (this.collection) {
       return {
-        models: this.collection.toJSON(),
+        models: this.collection,
         meta: this.collection.meta,
         params: this.collection.params
       };

--- a/test/shared/base/view.test.js
+++ b/test/shared/base/view.test.js
@@ -52,6 +52,31 @@ describe('BaseView', function() {
     });
   });
 
+  describe('getTemplateData', function () {
+
+    it('returns its model', function () {
+      var model =  { foo: 'bar' },
+          view = new BaseView({ model: model });
+
+      view.getTemplateData().should.deep.equal(model);
+    });
+
+    it('returns its collection as models', function () {
+      var collection = { models: [ {foo: 1} ] },
+          view = new BaseView({ collection: collection});
+
+      view.getTemplateData().should.deep.equal({ models: collection });
+    });
+
+    it('returns options if there is neither model nor collection', function () {
+      var options = { options: 1 },
+          view = new BaseView( options );
+
+      view.getTemplateData().should.deep.equal(options);
+    });
+
+  });
+
   describe('getAttributes', function () {
     beforeEach(function () {
       this.View = BaseView.extend({


### PR DESCRIPTION
I'm not sure if this is really a good idea as it potentiall breaks stuff ;) But, here's the problem I was facing:

I wanted to render a collection of ModelA, each using an existing view that can render that model. The view calls a helper method on `this.model`, and because of that the following collection view template fails to render because `this.model` is a JSON object in the view instantiated in the loop and not a model instance in the view:

``` handlebars
{{#each models}}
    {{view "my_model_view" model=this}}
{{/each}}
```

Note that I did not change the behaviour of also returning `meta` and `models` although that would not break any tests and both of those are already part of the collection anyway. This seems a bit odd as well..
