### PR TITLE
fixed the example location

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Rather than owning your entire Express app, Rendr simply provides some useful mi
 
 ### Asset pipeline
 
-Asset bundling and serving are outside of Rendr's scope. However, it does have some specific requirements for JavaScript packaging to support modules that are accessible in the CommonJS style on both the client and server. The [example app](https://github.com/airbnb/rendr-app-template) uses [Stitch](https://github.com/sstephenson/stitch) for this, though you could also do this with other tools, such as [Browserify](https://github.com/substack/node-browserify).
+Asset bundling and serving are outside of Rendr's scope. However, it does have some specific requirements for JavaScript packaging to support modules that are accessible in the CommonJS style on both the client and server. The [example app](https://github.com/airbnb/rendr/tree/master/examples/00_simple) uses [Stitch](https://github.com/sstephenson/stitch) for this, though you could also do this with other tools, such as [Browserify](https://github.com/substack/node-browserify).
 
 ## Notes
 


### PR DESCRIPTION
The example location is pointing to the old repo instead of the examples folder
