### PR TITLE
Adding ability to pass config/data to ViewEngine

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,7 @@ var defaultOptions = {
   dataAdapter: null,
   dataAdapterConfig: null,
   viewEngine: null,
+  viewEngineConfig: {},
   errorHandler: null,
   notFoundHandler: null,
   apiPath: '/api',
@@ -29,9 +30,9 @@ function Server(options) {
 
   this.expressApp = express();
 
-  this.dataAdapter = this.options.dataAdapter || new RestAdapter(this.options.dataAdapterConfig);;
+  this.dataAdapter = this.options.dataAdapter || new RestAdapter(this.options.dataAdapterConfig);
 
-  this.viewEngine = this.options.viewEngine || new ViewEngine();
+  this.viewEngine = this.options.viewEngine || new ViewEngine(this.options.viewEngineConfig);
 
   this.errorHandler = this.options.errorHandler =
     this.options.errorHandler || express.errorHandler();

--- a/server/viewEngine.js
+++ b/server/viewEngine.js
@@ -19,13 +19,15 @@ ViewEngine.prototype.render = function render(viewPath, data, callback) {
   var app, layoutData;
 
   data.locals = data.locals || {};
+  this.options.renderData = this.options.renderData || {};
   app = data.app;
-  layoutData = _.extend({}, data, {
+  layoutData = _.extend({}, this.options.renderData, data, {
     body: this.getViewHtml(viewPath, data.locals, app),
     appData: app.toJSON(),
     bootstrappedData: this.getBootstrappedData(data.locals, app),
     _app: app
   });
+
   this.renderWithLayout(layoutData, app, callback);
 };
 

--- a/test/server/viewEngine.test.js
+++ b/test/server/viewEngine.test.js
@@ -10,10 +10,10 @@ describe('ViewEngine', function() {
 
   beforeEach(function() {
 
-    viewEngine = new ViewEngine;
+    viewEngine = new ViewEngine({renderData: {render: 'data'}});
 
     function layoutTemplate(locals) {
-      return '<body>'+locals.body+'</body>';
+      return '<body>'+locals.body+'-'+locals.render+'</body>';
     }
 
     function View () {
@@ -42,9 +42,9 @@ describe('ViewEngine', function() {
     });
   });
 
-  it("should pass the rendered view template to the layout template", function(done) {
+  it("should pass the rendered view template to the layout template with the data in the render hash", function(done) {
     viewEngine.render('name', {app: app}, function (err, html) {
-      html.should.equal('<body>contents</body>');
+      html.should.equal('<body>contents-data</body>');
       done();
     });
   });


### PR DESCRIPTION
The desire here is to be able to pass data into the __layout.hbs when it is initially rendered on the server. It's data that we don't want to go into the actual app as it's too big and only needs to be generated once when the server starts up (eg: inline css).

Initially I'd created our own ViewEngine and was passing that into the server, but this seemed like such a small change, and that this.options hash was just forlornly sitting there begging to be used.

Using `renderData` feels a little cludgy, totally open to better naming, something more dynamic. 
