### PR TITLE
Pass collection options consistently

### DIFF
--- a/test/shared/fetcher.test.js
+++ b/test/shared/fetcher.test.js
@@ -112,6 +112,32 @@ describe('fetcher', function() {
     fetcher = this.app.fetcher;
   });
 
+  describe('buildOptions', function () {
+     it('should merge the app with custom options', function () {
+       fetcher.buildOptions().should.be.deep.equal({app: this.app});
+     });
+
+    it('should append specified additional options', function () {
+      fetcher.buildOptions({foo: 'bar'}).should.be.deep.equal({foo: 'bar', app: this.app});
+    });
+
+    it('should merge specified params with specified options that are empty', function () {
+      fetcher.buildOptions(null, {foo: 'bar'}).should.be.deep.equal({foo: 'bar', app: this.app});
+    });
+
+    it('should merge specified params with the specified options', function () {
+      var additionalOptions = {anyOption: 'withValue'},
+        params = {anyParam: 'paramValue'},
+        expected = {
+          app: this.app,
+          anyOption: 'withValue',
+          anyParam: 'paramValue'
+        };
+
+      fetcher.buildOptions(additionalOptions, params).should.be.deep.equal(expected);
+    });
+  });
+
   describe('getModelOrCollectionForSpec', function () {
     beforeEach(function () {
       sinon.stub(modelUtils, 'getModelConstructor').returns(BaseModel);


### PR DESCRIPTION
We recognized, that our collection was getting initialized multiple times with inconsistent options. The reason for this is, that there are different methods that do the preparation of the options:
- App.bootstrapData() -> getModelForSpec merged the spec params directly into the options
- App.start() -> Fetcher.hydrate() didn't merge the spec params

We refactored parts of the Fetcher class and added the merging to the hydrate method.
