### PR TITLE
Cleanup model utils

### DIFF
--- a/shared/modelUtils.js
+++ b/shared/modelUtils.js
@@ -1,11 +1,13 @@
 /*global rendr*/
 
-var BaseCollection, BaseModel, classMap, uppercaseRe, utils;
+var BaseCollection, BaseModel, uppercaseRe, utils;
 
 BaseModel = require('./base/model');
 BaseCollection = require('./base/collection');
 
 utils = module.exports;
+
+utils._classMap = {};
 
 utils.getModel = function(path, attrs, options) {
   var Model;
@@ -25,12 +27,12 @@ utils.getCollection = function(path, models, options) {
 
 utils.getModelConstructor = function(path) {
   path = utils.underscorize(path);
-  return classMap[path] || require(rendr.entryPath + "app/models/" + path);
+  return utils._classMap[path] || require(rendr.entryPath + "app/models/" + path);
 };
 
 utils.getCollectionConstructor = function(path) {
   path = utils.underscorize(path);
-  return classMap[path] || require(rendr.entryPath + "app/collections/" + path);
+  return utils._classMap[path] || require(rendr.entryPath + "app/collections/" + path);
 };
 
 utils.isModel = function(obj) {
@@ -46,16 +48,6 @@ utils.getModelNameForCollectionName = function(collectionName) {
 
   Collection = utils.getCollectionConstructor(collectionName);
   return utils.modelName(Collection.prototype.model);
-};
-
-classMap = {};
-
-/**
- * Use this to specify class constructors based on
- * model/collection name. Useful i.e. for testing.
- */
-utils.addClassMapping = function(key, modelConstructor) {
-  classMap[utils.underscorize(key)] = modelConstructor;
 };
 
 uppercaseRe = /([A-Z])/g;

--- a/test/helpers/add_class_mapping.js
+++ b/test/helpers/add_class_mapping.js
@@ -1,0 +1,9 @@
+utils = require('../../shared/modelUtils')
+
+/**
+ * Use this to specify class constructors based on
+ * model/collection name. Useful i.e. for testing.
+ */
+module.exports = function(key, modelConstructor) {
+  utils._classMap[utils.underscorize(key)] = modelConstructor;
+};

--- a/test/shared/base/collection.test.js
+++ b/test/shared/base/collection.test.js
@@ -1,4 +1,4 @@
-var App, BaseCollection, BaseModel, modelUtils, should, _;
+var App, BaseCollection, BaseModel, modelUtils, should, _, addClassMapping;
 
 _ = require('underscore');
 should = require('chai').should();
@@ -6,6 +6,7 @@ BaseCollection = require('../../../shared/base/collection');
 BaseModel = require('../../../shared/base/model');
 modelUtils = require('../../../shared/modelUtils');
 App = require('../../../shared/app');
+addClassMapping = require('../../helpers/add_class_mapping');
 
 describe('BaseCollection', function() {
   beforeEach(function() {
@@ -138,7 +139,7 @@ describe('BaseCollection', function() {
 
       this.MyCollection = BaseCollection.extend({});
 
-      modelUtils.addClassMapping(this.MyCollection.name, this.MyCollection);
+      addClassMapping(this.MyCollection.name, this.MyCollection);
     });
 
     it("should store its models in the modelStore and params in collectionStore", function() {

--- a/test/shared/base/model.test.js
+++ b/test/shared/base/model.test.js
@@ -1,9 +1,11 @@
-var App, BaseModel, modelUtils, should;
+var App, BaseModel, modelUtils, should, addClassMapping;
 
 should = require('chai').should();
 BaseModel = require('../../../shared/base/model');
 modelUtils = require('../../../shared/modelUtils');
 App = require('../../../shared/app');
+addClassMapping = require('../../helpers/add_class_mapping')
+
 
 describe('BaseModel', function() {
   beforeEach(function() {
@@ -12,7 +14,7 @@ describe('BaseModel', function() {
     this.MyModel = BaseModel.extend({});
     this.MyModel.id = 'MyModel';
 
-    modelUtils.addClassMapping(this.MyModel.id, this.MyModel);
+    addClassMapping(this.MyModel.id, this.MyModel);
   });
 
   it("should update modelStore when values change", function() {

--- a/test/shared/fetcher.test.js
+++ b/test/shared/fetcher.test.js
@@ -1,5 +1,5 @@
 var App, Listing, Listings, BaseCollection, BaseModel, fetcher, listingResponses,
-  modelUtils, sinon, chai, sinonChai, should, _;
+  modelUtils, sinon, chai, sinonChai, should, _, addClassMapping;
 
 _ = require('underscore');
 chai = require('chai');
@@ -10,6 +10,7 @@ modelUtils = require('../../shared/modelUtils');
 BaseModel = require('../../shared/base/model');
 BaseCollection = require('../../shared/base/collection');
 App = require('../../shared/app');
+addClassMapping = require('../helpers/add_class_mapping')
 
 chai.use(sinonChai);
 
@@ -67,8 +68,8 @@ Listings = BaseCollection.extend({
 });
 Listings.id = 'Listings';
 
-modelUtils.addClassMapping('Listing', Listing);
-modelUtils.addClassMapping('Listings', Listings);
+addClassMapping('Listing', Listing);
+addClassMapping('Listings', Listings);
 
 function getModelResponse(version, id, addJsonKey) {
   var resp;
@@ -405,7 +406,7 @@ describe('fetcher', function() {
         name: 'Some Person'
       };
       someperson = new User(userAttrs);
-      modelUtils.addClassMapping('user', User);
+      addClassMapping('user', User);
       fetcher.modelStore.set(someperson);
       fetchSpec = {
         model: {

--- a/test/shared/store/collection_store.test.js
+++ b/test/shared/store/collection_store.test.js
@@ -1,4 +1,4 @@
-var BaseCollection, BaseModel, CollectionStore, modelUtils, should, util;
+var BaseCollection, BaseModel, CollectionStore, modelUtils, should, util, addClassMapping;
 
 should = require('chai').should();
 util = require('util');
@@ -6,8 +6,9 @@ CollectionStore = require('../../../shared/store/collection_store');
 BaseCollection = require('../../../shared/base/collection');
 BaseModel = require('../../../shared/base/model');
 modelUtils = require('../../../shared/modelUtils');
+addClassMapping = require('../../helpers/add_class_mapping')
 
-modelUtils.addClassMapping(BaseCollection.name, BaseCollection);
+addClassMapping(BaseCollection.name, BaseCollection);
 
 describe('CollectionStore', function() {
   beforeEach(function() {
@@ -84,7 +85,7 @@ describe('CollectionStore', function() {
       params: params
     });
     this.store.set(collection, params);
-    modelUtils.addClassMapping(collection.constructor.name, MyCollection);
+    addClassMapping(collection.constructor.name, MyCollection);
     results = this.store.get(collection.constructor.name, params);
     results.should.eql({
       ids: collection.pluck('login'),

--- a/test/shared/store/model_store.test.js
+++ b/test/shared/store/model_store.test.js
@@ -1,4 +1,4 @@
-var BaseModel, ModelStore, modelUtils, should, _, util;
+var BaseModel, ModelStore, modelUtils, should, _, util, addClassMapping;
 
 util = require('util');
 _ = require('underscore');
@@ -6,6 +6,7 @@ should = require('chai').should();
 ModelStore = require('../../../shared/store/model_store');
 BaseModel = require('../../../shared/base/model');
 modelUtils = require('../../../shared/modelUtils');
+addClassMapping = require('../../helpers/add_class_mapping')
 
 
 function MyModel() {
@@ -15,7 +16,7 @@ util.inherits(MyModel, BaseModel);
 
 function App() {}
 
-modelUtils.addClassMapping(modelUtils.modelName(MyModel), MyModel);
+addClassMapping(modelUtils.modelName(MyModel), MyModel);
 
 describe('ModelStore', function() {
   beforeEach(function() {
@@ -99,7 +100,7 @@ describe('ModelStore', function() {
     }
     util.inherits(MySecondModel, BaseModel);
 
-    modelUtils.addClassMapping(modelUtils.modelName(MySecondModel), MySecondModel);
+    addClassMapping(modelUtils.modelName(MySecondModel), MySecondModel);
 
     it('should find a model on custom attributes', function(){
       var model, modelAttrs, result;


### PR DESCRIPTION
Just some refactoring.

I'm working on getting rid of rendr.entryPath and the modelUtils is the last place I have to tackle. (https://github.com/givingstage/rendr/tree/remove_global_entry_path)

This was just some (somewhat subjective) cleanup I decided to do. It's best to go through this pull request one commit at a time because they're somewhat unrelated to each other.
