### PR TITLE
Support 'spec.needsFetch === true' in Fetcher

### DIFF
--- a/shared/fetcher.js
+++ b/shared/fetcher.js
@@ -171,6 +171,7 @@ Fetcher.prototype._retrieveModel = function(spec) {
 Fetcher.prototype.needsFetch = function(modelData, spec) {
   if (modelData == null) return true;
   if (this.isMissingKeys(modelData, spec.ensureKeys)) return true;
+  if (spec.needsFetch === true) return true;
   if (typeof spec.needsFetch === 'function' && spec.needsFetch(modelData)) return true;
   return false;
 };


### PR DESCRIPTION
As an easy way to force a specific resource to be fetched fresh, and not
from the ModelStore or CollectionStore.

```
var spec = {
  model: {model: 'User', params: {id: 1234}, needsFetch: true}
};
this.app.fetch(spec, callback);
```

Previously, `spec.needsFetch` could be a function that accepts the model
data from the store and returns true or false.

Another way to force fetching is to use the `{readFromCache: false}`
option in `Fetcher#fetch`, but that option applies to the whole fetch,
not per-resource, like `spec.needsFetch` does.

```
var spec = {
  model: {model: 'User', params: {id: 1234}}
};
this.app.fetch(spec, {readFromCache: false}, callback);
```

/cc @cdupont
