### PR TITLE
allow rendr to be mounted on nested url

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -1,6 +1,6 @@
 /*global rendr*/
 
-var AppView, Backbone, BaseRouter, BaseView, ClientRouter, extractParamNamesRe, firstRender, plusRe, _;
+var AppView, Backbone, BaseRouter, BaseView, ClientRouter, extractParamNamesRe, firstRender, plusRe, _, defaultRootPath;
 
 _ = require('underscore');
 Backbone = require('backbone');
@@ -12,6 +12,8 @@ extractParamNamesRe = /:(\w+)/g;
 plusRe = /\+/g;
 
 firstRender = true;
+
+defaultRootPath = '';
 
 function noop() {}
 
@@ -245,7 +247,8 @@ ClientRouter.prototype.renderView = function() {
 ClientRouter.prototype.start = function() {
   Backbone.history.start({
     pushState: true,
-    hashChange: false
+    hashChange: false,
+    root: this.options.rootPath || defaultRootPath
   });
 };
 

--- a/shared/app.js
+++ b/shared/app.js
@@ -63,7 +63,8 @@ module.exports = Backbone.Model.extend({
     if (!global.isServer) {
       new ClientRouter({
         app: this,
-        entryPath: clientEntryPath
+        entryPath: clientEntryPath,
+        rootPath: attributes.rootPath
       });
     }
 


### PR DESCRIPTION
Backbone.history.start can take a `root` if you're mounting the backbone app on nested url. 

http://backbonejs.org/#History-start

you use this by starting a rendr sever with 

``` coffee
app.use rendr.createServer(appData: {rootPath: '/cool-rendr-app'})
```

`Root` is a very generic name so I called it `rootPath`.
