### PR TITLE
The app_view try / catch is making me crazy

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -1,12 +1,11 @@
 /*global rendr*/
 
-var AppView, Backbone, BaseRouter, BaseView, ClientRouter, extractParamNamesRe, firstRender, plusRe, _, defaultRootPath, RendrAppView;
+var AppView, Backbone, BaseRouter, BaseView, ClientRouter, extractParamNamesRe, firstRender, plusRe, _, defaultRootPath;
 
 _ = require('underscore');
 Backbone = require('backbone');
 BaseRouter = require('../shared/base/router');
 BaseView = require('../shared/base/view');
-RendrAppView = require('./app_view');
 
 extractParamNamesRe = /:(\w+)/g;
 
@@ -55,7 +54,7 @@ ClientRouter.prototype.reverseRoutes = true;
 ClientRouter.prototype.initialize = function(options) {
   this.app = options.app;
 
-  var AppView = this.app.customAppView || RendrAppView;
+  var AppView = this.options.appViewClass;
 
   // We do this here so that it's available in AppView initialization.
   this.app.router = this;

--- a/shared/app.js
+++ b/shared/app.js
@@ -10,7 +10,7 @@ var Backbone, ClientRouter, Fetcher, ModelUtils;
 require('./globals');
 Backbone = require('backbone');
 Fetcher = require('./fetcher');
-ModelUtils = require('./modelUtils')
+ModelUtils = require('./modelUtils');
 
 if (!global.isServer) {
   ClientRouter = require('app/router');
@@ -66,6 +66,7 @@ module.exports = Backbone.Model.extend({
       new ClientRouter({
         app: this,
         entryPath: entryPath,
+        appViewClass: this.getAppViewClass(),
         rootPath: attributes.rootPath
       });
     }
@@ -84,6 +85,13 @@ module.exports = Backbone.Model.extend({
    */
   fetch: function() {
     this.fetcher.fetch.apply(this.fetcher, arguments);
+  },
+
+  /**
+   * @client
+   */
+  getAppViewClass: function () {
+    return require('../client/app_view');
   },
 
   /**


### PR DESCRIPTION
if the app_view in my app has an error, rendr quietly falls back to using it's own app_view.  Which is tricky to notice, as rendr's app_view does most of the work already. So trying to make this a bit more rendr-standard and allow passing in of a app_view object.

But this is only a partial PR.  Getting the customAppView set on the app requires overriding the `initialize` method in the app's app_view, setting the `customAppView`, and then calling `BaseApp.prototype.initialize.apply(this, arguments);` at the end of it.  I'm not thrilled about that as a solution, so I wanted to check in and get people's thoughts before adding a `preInitialize()` method, or if I'm missing a better way to get this into the base app.
