### PR TITLE
Guard against null getResponseHeader('content-type') in clientSync

### DIFF
--- a/shared/syncer.js
+++ b/shared/syncer.js
@@ -38,7 +38,7 @@ function clientSync(method, model, options) {
       var body, contentType, resp;
       body = xhr.responseText;
       contentType = xhr.getResponseHeader('content-type');
-      if (contentType.indexOf('application/json') !== -1) {
+      if (contentType && contentType.indexOf('application/json') !== -1) {
         try {
           body = JSON.parse(body);
         } catch (e) {


### PR DESCRIPTION
Possibly from browser restrictions, jquery throwing a parseerror from malformed JSON, etc.
