### PR TITLE
Added templatePath and compiledTemplatesFile Server.options

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -54,11 +54,7 @@ ClientRouter.prototype.reverseRoutes = true;
 ClientRouter.prototype.initialize = function(options) {
   this.app = options.app;
 
-  try {
-    AppView = require(options.entryPath + 'app/views/app_view');
-  } catch (e) {
-    AppView = require('./app_view');
-  }
+  var AppView = this.options.appViewClass;
 
   // We do this here so that it's available in AppView initialization.
   this.app.router = this;

--- a/server/middleware/initApp.js
+++ b/server/middleware/initApp.js
@@ -27,7 +27,9 @@ module.exports = function(appAttributes, options) {
        */
       req: req,
       entryPath: options.entryPath,
-      modelUtils: options.modelUtils
+      modelUtils: options.modelUtils,
+      templatePath: options.templatePath,
+      compiledTemplatesFile: options.compiledTemplatesFile
     };
 
     /**

--- a/server/server.js
+++ b/server/server.js
@@ -5,7 +5,9 @@ var _ = require('underscore')
   , Router = require('./router')
   , RestAdapter = require('./data_adapter/rest_adapter')
   , ViewEngine = require('./viewEngine')
-  , middleware = require('./middleware');
+  , middleware = require('./middleware'),
+    path = require('path'),
+    fs = require('fs');
 
 module.exports = Server;
 
@@ -22,10 +24,11 @@ function defaultOptions(){
     paths: {},
     viewsPath: null,
     defaultEngine: 'js',
-    entryPath: process.cwd() + '/'
+    entryPath: process.cwd() + '/',
+    templatePath: '/app/templates/',
+    compiledTemplatesFile: '/app/templates/compiledTemplates.js'
   };
 }
-
 
 function Server(options) {
   if(typeof rendr !== 'undefined' && rendr.entryPath){
@@ -33,8 +36,7 @@ function Server(options) {
     options.entryPath = rendr.entryPath;
   }
 
-  this.options = options || {};
-  _.defaults(this.options, defaultOptions());
+  this.options = this.initOptions(options, defaultOptions());
 
   this.expressApp = express();
 
@@ -46,6 +48,7 @@ function Server(options) {
     this.options.errorHandler || express.errorHandler();
 
   this.router = new Router(this.options);
+
 
   /**
    * Tell Express to use our ViewEngine to handle .js, .coffee files.
@@ -71,6 +74,29 @@ function Server(options) {
       this.expressApp.handle(req, res, next);
     }.bind(this);
   });
+}
+
+
+/**
+ * Make sure the options are defaulted properly and resolve paths
+ */
+Server.prototype.initOptions = function(options, defaultOptions) {
+  options = options || {};
+  options = _.defaults(options, defaultOptions);
+
+  if (!fs.existsSync(options.entryPath)) {
+    throw new Error("Rendr - Invalid entryPath: [" + options.entryPath + "]")
+  }
+
+  options.entryPath = path.normalize(options.entryPath);
+
+  /**
+  * Resolve these options to absolute paths
+  */
+  options.templatePath = path.join(options.entryPath, options.templatePath);
+  options.compiledTemplatesFile = path.join(options.entryPath, options.compiledTemplatesFile);
+
+  return options;
 }
 
 /**
@@ -108,7 +134,9 @@ Server.prototype.configure = function(fn) {
   this.expressApp.use(middleware.initApp(this.options.appData, {
     apiPath: this.options.apiPath,
     entryPath: this.options.entryPath,
-    modelUtils: this.options.modelUtils
+    modelUtils: this.options.modelUtils,
+    templatePath: this.options.templatePath,
+    compiledTemplatesFile: this.options.compiledTemplatesFile
   }));
 
   /**

--- a/server/viewEngine.js
+++ b/server/viewEngine.js
@@ -49,7 +49,7 @@ ViewEngine.prototype.getLayoutTemplate = function getLayoutTemplate(app, callbac
   if (layoutTemplates[app.options.entryPath]) {
     return callback(null, layoutTemplates[app.options.entryPath]);
   }
-  app.templateAdapter.getLayout('__layout', app.options.entryPath, function(err, template) {
+  app.templateAdapter.getLayout('__layout', app.options, function(err, template) {
     if (err) return callback(err);
     layoutTemplates[app.options.entryPath] = template;
     callback(err, template);

--- a/test/client/router.test.js
+++ b/test/client/router.test.js
@@ -5,6 +5,7 @@ should = require('chai').should();
 
 App = require('../../shared/app');
 BaseView = require('../../shared/base/view');
+AppView = require('../../client/app_view');
 Router = require('../../client/router');
 clientTestHelper = require('../helpers/client_test');
 
@@ -12,7 +13,8 @@ routerConfig = {
   app: new App,
   paths: {
     entryPath: __dirname + "/../fixtures/"
-  }
+  },
+  appViewClass: AppView,
 };
 
 describe("client/router", function() {

--- a/test/server/server.test.js
+++ b/test/server/server.test.js
@@ -6,14 +6,40 @@ Server = require('../../server/server');
 describe("server/server", function() {
 
   describe('express render Engine', function(){
+
     it("should have a default", function() {
       server = new Server();
       server.expressApp.get('view engine').should.equal('js')
     });
+
     it("should be able to be changed", function() {
       server = new Server({defaultEngine: 'other render engine'});
       server.expressApp.get('view engine').should.equal('other render engine')
     });
+
+
+    it("should have a default templatePath", function() {
+      server = new Server();
+      server.options.templatePath.should.equal(server.options.entryPath + 'app/templates/')
+    });
+
+    it("should have an overridden templatePath", function() {
+      server = new Server({templatePath: 'app/'});
+      server.options.templatePath.should.equal(server.options.entryPath + 'app/')
+    });
+
+
+
+    it("should have a default compiledTemplatesFile", function() {
+      server = new Server();
+      server.options.compiledTemplatesFile.should.equal(server.options.entryPath + 'app/templates/compiledTemplates.js')
+    });
+
+    it("should have an overridden compiledTemplatesFile", function() {
+      server = new Server({compiledTemplatesFile: 'test/'});
+      server.options.compiledTemplatesFile.should.equal(server.options.entryPath + 'test/')
+    });
+
   });
 
 });


### PR DESCRIPTION
Defaults to paths outlined in Rendr readme with Server.options overriding them.  I've updated the tests

---

Everything is relative to entryPath and it also resolves paths.

```
{ 
entryPath: '/my_app/'
templatePath: '/app/views/'
compiledTemplates: '../tmp/compiled_templates.js'
}
```

In order for this to work, I had to pull out the hardcoded template path within rendr-handlebars:index.js:27

```
localExports.templatePatterns.push({pattern: /.+/, src: options.entryPath + 'app/templates/compiledTemplates'})
```

I have a fork of rendr-handlebars that makes that an option.  I can send you a pull request of that as well.

The one thing that I'd like to see is a configuration of "__layout".  My thinking here is that it should somehow be incorporated into App & Views.  So you can say this App uses __layoutX, but these five views can override with  __layoutG.
