### PR TITLE
added modelInstances cache to modelUtils.

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -60,6 +60,7 @@ ClientRouter.prototype.initialize = function(options) {
   this.app.router = this;
 
   this.on('route:add', this.addBackboneRoute, this);
+  this.on('action:start', this.app.modelUtils.clean, this.app.modelUtils);
   this.on('action:start', this.trackAction, this);
   this.app.on('reload', this.renderView, this);
 

--- a/shared/modelUtils.js
+++ b/shared/modelUtils.js
@@ -8,13 +8,23 @@ module.exports = ModelUtils = (function() {
   function ModelUtils(entryPath) {
     this.entryPath = entryPath;
     this._classMap = {};
+    this.modelInstances = {};
+  }
+
+  ModelUtils.prototype.clean = function(){
+    this.modelInstances = {};
   }
 
   ModelUtils.prototype.getModel = function(path, attrs, options) {
-    var Model;
+    var Model, modelId, key;
     attrs = attrs || {};
     options = options || {};
     Model = this.getModelConstructor(path);
+    modelId = attrs[this.modelIdAttribute(path)];
+    if (modelId && !isServer) {
+      key = path+":"+modelId;
+      return this.modelInstances[key] || (this.modelInstances[key] = new Model(attrs, options));
+    }
     return new Model(attrs, options);
   };
 


### PR DESCRIPTION
This fixes the problem of each view getting a new version of the same model.
This way models can trigger events and have different views listen to those events.

It gets cleared on every new action and isn't run on the server.
This way they can be garbage collected along with the associated events and views.

addresses https://github.com/airbnb/rendr/issues/167

I didn't write any tests because I don't know if this is a direction we should go. But it does work. If y'all like this blunt implementation I'll add some tests.
