### PR TITLE
Custom apiProxy server option

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -22,7 +22,8 @@ function defaultOptions(){
     paths: {},
     viewsPath: null,
     defaultEngine: 'js',
-    entryPath: process.cwd() + '/'
+    entryPath: process.cwd() + '/',
+    apiProxy: null
   };
 }
 
@@ -32,7 +33,6 @@ function Server(options) {
     console.warn("Setting rendr.entryPath is now deprecated. Please pass in entryPath when initializing the rendr server.")
     options.entryPath = rendr.entryPath;
   }
-
   this.options = options || {};
   _.defaults(this.options, defaultOptions());
 
@@ -120,7 +120,8 @@ Server.prototype.configure = function(fn) {
   /**
    * Add the API handler.
    */
-  this.expressApp.use(this.options.apiPath, middleware.apiProxy(dataAdapter));
+  this.options.apiProxy = this.options.apiProxy || middleware.apiProxy;
+  this.expressApp.use(this.options.apiPath, this.options.apiProxy(dataAdapter));
 
   /**
    * Add the routes for everything defined in our routes file.


### PR DESCRIPTION
I have a situation where I don't need the apiProxy. Calls go directly to an endpoint on the same server. This change seemed like the most painless way of making that happen.

To get it working with no proxy, I did the following:

1) Name the entries in dataAdapterConfig the version of the API "v1": {...}

2) Override syncer.formatClientUrl in the Base Model/Collection to skip adding the /-/ separator, otherwise identical.

3) Set config.apiProxy to noop

result is /api/v1/myresource -> app server = ok!

I could see the no-proxy being an option that does all of this.  It prevents the middleware from hooking on and eliminates the addition of the separator.
