### PR TITLE
Remove all use of globals

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -1,5 +1,3 @@
-/*global rendr*/
-
 // Since we make rendr files AMD friendly on app setup stage
 // we need to pretend that this code is pure commonjs
 // means no AMD-style require calls

--- a/examples/05_requirejs/Gruntfile.js
+++ b/examples/05_requirejs/Gruntfile.js
@@ -171,9 +171,6 @@ module.exports = function(grunt) {
           cjsTranslate: true,
           create: true,
           name: 'rendr-handlebars',
-          rawText: {
-            'rendr/shared/globals': 'define(["rendr/shared/globals"], function () {});'
-          },
           include: [
             'rendr-handlebars'
           ],
@@ -217,11 +214,9 @@ module.exports = function(grunt) {
           dir: 'public/js/rendr/shared',
           baseUrl: './rendr/shared',
           cjsTranslate: true,
-          insertRequire: ['rendr/shared/globals'],
           paths: {
             'rendr/shared': '../..',
             'rendr/client': '../../../client',
-            'globals': '../../globals'
           },
           rawText: {
             'app/router': 'define(["app/router"], function () {});'
@@ -232,9 +227,8 @@ module.exports = function(grunt) {
             {name: 'async', location: 'rendr/node_modules/async/lib', main: 'async.js'}
           ],
           modules: [
-            { name: 'rendr/shared/app', exclude: ['backbone', 'rendr/shared/globals', 'rendr/shared/fetcher', 'app/router'] },
+            { name: 'rendr/shared/app', exclude: ['backbone', 'rendr/shared/fetcher', 'app/router'] },
             { name: 'rendr/shared/fetcher', exclude: ['underscore', 'backbone', 'async', 'rendr/shared/modelUtils', 'rendr/shared/store/model_store', 'rendr/shared/store/collection_store'] },
-            { name: 'rendr/shared/globals' },
             { name: 'rendr/shared/modelUtils', exclude: ['rendr/shared/base/model', 'rendr/shared/base/collection'] },
             { name: 'rendr/shared/syncer', exclude: ['underscore', 'backbone'] },
             { name: 'rendr/shared/base/collection', exclude: ['underscore', 'backbone', 'rendr/shared/syncer', 'rendr/shared/base/model'] },

--- a/server/middleware/initApp.js
+++ b/server/middleware/initApp.js
@@ -1,5 +1,3 @@
-/*global rendr*/
-
 /**
  * We add `req.rendrApp` so any middleware can access the Rendr
  * app. We need to inject it into views, models, etc., in order

--- a/server/server.js
+++ b/server/server.js
@@ -1,5 +1,3 @@
-require('../shared/globals');
-
 var _ = require('underscore')
   , express = require('express')
   , Router = require('./router')

--- a/server/viewEngine.js
+++ b/server/viewEngine.js
@@ -1,5 +1,3 @@
-/*global rendr*/
-
 var path = require('path')
   , _ = require('underscore')
   , layoutTemplates = {};

--- a/shared/app.js
+++ b/shared/app.js
@@ -1,18 +1,16 @@
-/*global rendr*/
-
 /**
  * This is the app instance that is shared between client and server.
  * The client also subclasses it for client-specific stuff.
  */
 
-var Backbone, ClientRouter, Fetcher, ModelUtils;
+var Backbone, ClientRouter, Fetcher, ModelUtils, isServer;
 
-require('./globals');
 Backbone = require('backbone');
 Fetcher = require('./fetcher');
 ModelUtils = require('./modelUtils');
+isServer = (typeof window === 'undefined');
 
-if (!global.isServer) {
+if (!isServer) {
   ClientRouter = require('app/router');
 }
 
@@ -32,7 +30,7 @@ module.exports = Backbone.Model.extend({
     this.options = options || {};
 
     var entryPath = this.options.entryPath || '';
-    if (!global.isServer) {
+    if (!isServer) {
       // the entry path must always be empty for the client
       entryPath =  '';
     }
@@ -62,7 +60,7 @@ module.exports = Backbone.Model.extend({
     /**
      * Initialize the `ClientRouter` on the client-side.
      */
-    if (!global.isServer) {
+    if (!isServer) {
       new ClientRouter({
         app: this,
         entryPath: entryPath,

--- a/shared/base/router.js
+++ b/shared/base/router.js
@@ -1,9 +1,8 @@
-/*global rendr*/
-
-var Backbone, BaseRouter, noop, _;
+var Backbone, BaseRouter, noop, _, isServer;
 
 _ = require('underscore');
 Backbone = require('backbone');
+isServer = (typeof window === 'undefined');
 
 function noop() {}
 
@@ -56,7 +55,7 @@ BaseRouter.prototype.getController = function(controllerName) {
   // for requirejs return path that will be lazy loaded
   controllerPath = controllerDir + "/" + controllerName + "_controller";
 
-  if (!global.isServer && typeof define !== 'undefined') {
+  if (!isServer && typeof define !== 'undefined') {
     controller = controllerPath;
   } else {
     controller = require(controllerPath);

--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -1,5 +1,3 @@
-/*global rendr*/
-
 // Since we make rendr files AMD friendly on app setup stage
 // we need to pretend that this code is pure commonjs
 // means no AMD-style require calls

--- a/shared/fetcher.js
+++ b/shared/fetcher.js
@@ -1,8 +1,9 @@
-var Backbone, CollectionStore, ModelStore, async, _;
+var Backbone, CollectionStore, ModelStore, async, _, isServer;
 
 _ = require('underscore');
 Backbone = require('backbone');
 async = require('async');
+isServer = (typeof window === 'undefined');
 
 ModelStore = require('./store/model_store');
 CollectionStore = require('./store/collection_store');
@@ -154,7 +155,7 @@ Fetcher.prototype._retrieveModelData = function(spec, modelData, modelOptions, c
      * return the cached object we fire off a fetch, compare the results,
      * and if the data is different, we trigger a 'refresh' event.
      */
-    if (spec.checkFresh && !global.isServer && this.shouldCheckFresh(spec)) {
+    if (spec.checkFresh && !isServer && this.shouldCheckFresh(spec)) {
       model.checkFresh();
       this.didCheckFresh(spec);
     }
@@ -358,7 +359,7 @@ Fetcher.prototype.fetch = function(fetchSpecs, options, callback) {
   }
 
   // Different defaults for client v server.
-  if (global.isServer) {
+  if (isServer) {
     if (options.readFromCache == null) {
       options.readFromCache = false;
     }

--- a/shared/globals.js
+++ b/shared/globals.js
@@ -1,6 +1,0 @@
-if (typeof window !== "undefined" && window !== null) {
-  window.isServer = false;
-  window.global = window;
-} else {
-  global.isServer = true;
-}

--- a/shared/syncer.js
+++ b/shared/syncer.js
@@ -15,9 +15,12 @@ var _ = require('underscore')
     'update': 'PUT',
     'delete': 'DELETE',
     'read': 'GET'
-  };
+  }
 
-if (global.isServer) {
+  , isServer = (typeof window === 'undefined')
+;
+
+if (isServer) {
   // hide it from requirejs since it's server only
   var serverOnly_qs = 'qs';
   var qs = require(serverOnly_qs);
@@ -121,7 +124,7 @@ function addApiParams(method, model, params) {
 }
 
 syncer.sync = function sync() {
-  var syncMethod = global.isServer ? serverSync : clientSync;
+  var syncMethod = isServer ? serverSync : clientSync;
   return syncMethod.apply(this, arguments);
 };
 

--- a/test/client/router.test.js
+++ b/test/client/router.test.js
@@ -11,7 +11,7 @@ clientTestHelper = require('../helpers/client_test');
 AppViewClass = require('../../client/app_view');
 
 routerConfig = {
-  app: new App,
+  app: new App({}, {}),
   appViewClass: AppViewClass,
   paths: {
     entryPath: __dirname + "/../fixtures/"


### PR DESCRIPTION
Remove `shared/globals.js` and all use of globals. We were using
`global.isServer`, as well as `global.rendr`. These are no longer
needed, and it's poor practice to expose globals in Node.

Also remove the `/*global rendr*/` JSHint comments.
