### PR TITLE
Use _.result for views' id, className and tagName attributes. Like Backbone.

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -231,14 +231,15 @@ module.exports = BaseView = Backbone.View.extend({
    * Get the HTML for the view, including the wrapper element.
    */
   getHtml: function() {
-    var attrString, attributes, html;
+    var attrString, attributes, html, tagName;
 
     html = this.getInnerHtml();
     attributes = this.getAttributes();
     attrString = _.inject(attributes, function(memo, value, key) {
       return memo += " " + key + "=\"" + _.escape(value) + "\"";
     }, '');
-    return "<" + this.tagName + attrString + ">" + html + "</" + this.tagName + ">";
+    tagName = _.result(this, "tagName");
+    return "<" + tagName + attrString + ">" + html + "</" + tagName + ">";
   },
 
   render: function() {


### PR DESCRIPTION
Backbone does this when it created the view's HTML: https://github.com/jashkenas/backbone/blob/master/backbone.js#L1097-L1100

I think it would be good to mimic how Backbone does this.
