### PR TITLE
Updated dependencies to make `05` work.

### DIFF
--- a/examples/05_requirejs/package.json
+++ b/examples/05_requirejs/package.json
@@ -11,8 +11,8 @@
     "express": "~3",
     "underscore": "~1.4.4",
     "async": "~0.1.22",
-    "rendr-handlebars": "0.1.0",
-    "rendr": "0.5.0-alpha09",
+    "rendr-handlebars": "airbnb/rendr-handlebars#b204579aeea86bef27bb6c0a513bdb335c303558",
+    "rendr": "airbnb/rendr#99c34f75b5b10bc1efd194677341a652b8b2ad17",
     "amdefine": "~0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Recent changes to `rendr` and `rendr-handlebars` are not in tags/packages yet, so for now (to make example work) I changed it to commits.
(tests are failing too, work in progress)
