### PR TITLE
Remove hbsfy Browserify transform from examples

### DIFF
--- a/examples/00_simple/Gruntfile.js
+++ b/examples/00_simple/Gruntfile.js
@@ -72,7 +72,6 @@ module.exports = function(grunt) {
         dest: 'public/mergedAssets.js',
         options: {
           debug: true,
-          transform: ['hbsfy'],
           alias: [
             'node_modules/rendr-handlebars/index.js:rendr-handlebars',
           ],

--- a/examples/00_simple/package.json
+++ b/examples/00_simple/package.json
@@ -21,7 +21,6 @@
     "grunt-contrib-stylus": "~0.5.0",
     "grunt-contrib-handlebars": "~0.5.11",
     "grunt-contrib-watch": "~0.3.1",
-    "hbsfy": "~1.0.0",
     "nodemon": "~0.7.6",
     "mocha": "~1.9.0",
     "chai": "~1.8.1",

--- a/examples/01_config/Gruntfile.js
+++ b/examples/01_config/Gruntfile.js
@@ -75,7 +75,6 @@ module.exports = function(grunt) {
         dest: 'public/mergedAssets.js',
         options: {
           debug: true,
-          transform: ['hbsfy'],
           alias: [
             'node_modules/rendr-handlebars/index.js:rendr-handlebars',
           ],

--- a/examples/01_config/package.json
+++ b/examples/01_config/package.json
@@ -22,7 +22,6 @@
     "grunt-contrib-stylus": "~0.5.0",
     "grunt-contrib-handlebars": "~0.5.11",
     "grunt-contrib-watch": "~0.3.1",
-    "hbsfy": "~1.0.0",
     "nodemon": "~0.7.6",
     "mocha": "~1.9.0",
     "should": "~1.2.2"

--- a/examples/02_middleware/Gruntfile.js
+++ b/examples/02_middleware/Gruntfile.js
@@ -75,7 +75,6 @@ module.exports = function(grunt) {
         dest: 'public/mergedAssets.js',
         options: {
           debug: true,
-          transform: ['hbsfy'],
           alias: [
             'node_modules/rendr-handlebars/index.js:rendr-handlebars',
           ],

--- a/examples/02_middleware/package.json
+++ b/examples/02_middleware/package.json
@@ -22,7 +22,6 @@
     "grunt-contrib-stylus": "~0.5.0",
     "grunt-contrib-handlebars": "~0.5.11",
     "grunt-contrib-watch": "~0.3.1",
-    "hbsfy": "~1.0.0",
     "nodemon": "~0.7.6",
     "mocha": "~1.9.0",
     "should": "~1.2.2"

--- a/examples/03_sessions/Gruntfile.js
+++ b/examples/03_sessions/Gruntfile.js
@@ -75,7 +75,6 @@ module.exports = function(grunt) {
         dest: 'public/mergedAssets.js',
         options: {
           debug: true,
-          transform: ['hbsfy'],
           alias: [
             'node_modules/rendr-handlebars/index.js:rendr-handlebars',
           ],

--- a/examples/03_sessions/package.json
+++ b/examples/03_sessions/package.json
@@ -22,7 +22,6 @@
     "grunt-contrib-stylus": "~0.5.0",
     "grunt-contrib-handlebars": "~0.5.11",
     "grunt-contrib-watch": "~0.3.1",
-    "hbsfy": "~1.0.0",
     "nodemon": "~0.7.6",
     "mocha": "~1.9.0",
     "should": "~1.2.2"

--- a/examples/04_entrypath/Gruntfile.js
+++ b/examples/04_entrypath/Gruntfile.js
@@ -71,7 +71,6 @@ module.exports = function(grunt) {
         dest: 'public/mergedAssets.js',
         options: {
           debug: true,
-          transform: ['hbsfy'],
           alias: [
             'node_modules/rendr-handlebars/index.js:rendr-handlebars',
           ],

--- a/examples/04_entrypath/package.json
+++ b/examples/04_entrypath/package.json
@@ -23,7 +23,6 @@
     "grunt-contrib-stylus": "~0.5.0",
     "grunt-contrib-handlebars": "~0.5.11",
     "grunt-contrib-watch": "~0.3.1",
-    "hbsfy": "~1.0.0",
     "nodemon": "~0.7.6",
     "mocha": "~1.9.0",
     "should": "~1.2.2"

--- a/examples/06_appview/Gruntfile.js
+++ b/examples/06_appview/Gruntfile.js
@@ -74,7 +74,6 @@ module.exports = function(grunt) {
         dest: 'public/mergedAssets.js',
         options: {
           debug: true,
-          transform: ['hbsfy'],
           alias: [
             'node_modules/rendr-handlebars/index.js:rendr-handlebars',
           ],

--- a/examples/06_appview/package.json
+++ b/examples/06_appview/package.json
@@ -20,7 +20,6 @@
     "grunt-contrib-stylus": "~0.5.0",
     "grunt-contrib-handlebars": "~0.5.11",
     "grunt-contrib-watch": "~0.3.1",
-    "hbsfy": "~1.0.0",
     "nodemon": "~0.7.6",
     "mocha": "~1.9.0",
     "chai": "~1.8.1",


### PR DESCRIPTION
The `hbsfy` Browserify transform was listed in the `package.json` and
`Gruntfile.js` for the example apps, however it was not used.  I would
love to move to actually using it eventually (and not the
`app/templates/compiledTemplates.js` bullcrap), but we're not there yet.
