### PR TITLE
Fixes issue #225

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -497,6 +497,8 @@ BaseView.attach = function(app, parentView, callback) {
         view.attach($el, parentView);
         cb(null, view);
       });
+    } else {
+      cb(null, null);
     }
   }, function(err, views) {
     // no error handling originally


### PR DESCRIPTION
Turns out that the root of the problem wasn't async after all – they did fix a quirk with that call though.  The issue is that there is a missing callback if you have nested views.
