### PR TITLE
Use the View for attaching, not the template

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -174,7 +174,7 @@ module.exports = BaseView = Backbone.View.extend({
 
     // Add `data-view` attribute with view key.
     // For now, view key is same as template.
-    attributes['data-view'] = this.name;
+    attributes['data-view'] = this.constructor.id || this.name;
 
     // Add model & collection meta data from options,
     // as well as any non-object option values.


### PR DESCRIPTION
Given a view with a `name` property to render a different template, when attaching the DOM to the view, this would originally try to get a view with the same name as the `name` property.

With this change, it looks for the view's proper name instead of the template's name.
