### PR TITLE
Sweep codebase for style tweaks

### DIFF
--- a/client/app_view.js
+++ b/client/app_view.js
@@ -1,8 +1,7 @@
-var _ = require('underscore')
-  , Backbone = require('backbone')
-  , BaseView = require('../shared/base/view')
-  , $ = (typeof window !== 'undefined' && window.$) || require('jquery')
-;
+var _ = require('underscore'),
+    Backbone = require('backbone'),
+    BaseView = require('../shared/base/view'),
+    $ = (typeof window !== 'undefined' && window.$) || require('jquery');
 
 Backbone.$ = $;
 

--- a/client/router.js
+++ b/client/router.js
@@ -1,23 +1,19 @@
-// Since we make rendr files AMD friendly on app setup stage
-// we need to pretend that this code is pure commonjs
-// means no AMD-style require calls
+/**
+ * Since we make rendr files AMD friendly on app setup stage
+ * we need to pretend that this code is pure commonjs
+ * means no AMD-style require calls
+ */
 var requireAMD = require;
 
-var AppView, Backbone, BaseRouter, BaseView, ClientRouter, extractParamNamesRe, firstRender, plusRe, _, defaultRootPath, $;
-
-_ = require('underscore');
-Backbone = require('backbone');
-BaseRouter = require('../shared/base/router');
-BaseView = require('../shared/base/view');
-$ = (typeof window !== 'undefined' && window.$) || require('jquery');
-
-extractParamNamesRe = /:(\w+)/g;
-
-plusRe = /\+/g;
-
-firstRender = true;
-
-defaultRootPath = '';
+var _ = require('underscore'),
+    Backbone = require('backbone'),
+    BaseRouter = require('../shared/base/router'),
+    BaseView = require('../shared/base/view'),
+    $ = (typeof window !== 'undefined' && window.$) || require('jquery'),
+    extractParamNamesRe = /:(\w+)/g,
+    plusRe = /\+/g,
+    firstRender = true,
+    defaultRootPath = '';
 
 Backbone.$ = $;
 
@@ -40,18 +36,18 @@ ClientRouter.prototype.currentFragment = null;
 
 ClientRouter.prototype.previousFragment = null;
 
-/*
+/**
  * In a controller action, can access the current route
  * definition with `this.currentRoute`.
  */
 ClientRouter.prototype.currentRoute = null;
 
-/*
+/**
  * Instance of Backbone.Router used to manage browser history.
  */
 ClientRouter.prototype._router = null;
 
-/*
+/**
  * We need to reverse the routes in the client because
  * Backbone.History matches in reverse.
  */
@@ -80,7 +76,7 @@ ClientRouter.prototype.initialize = function(options) {
 
 ClientRouter.prototype.postInitialize = noop;
 
-/*
+/**
  * Piggyback on adding new route definition events
  * to also add to Backbone.Router.
  */
@@ -122,7 +118,7 @@ ClientRouter.prototype.getHandler = function(action, pattern, route) {
       params = router.getParamsHash(pattern, paramsArray, window.location.search);
 
       redirect = router.getRedirect(route, params);
-      /*
+      /**
        * If `redirect` is present, then do a redirect and return.
        */
       if (redirect != null) {
@@ -149,7 +145,7 @@ ClientRouter.prototype.getHandler = function(action, pattern, route) {
   };
 };
 
-/*
+/**
  * Can be overridden by applications
  * if the initial render is more complicated.
  */
@@ -160,7 +156,7 @@ ClientRouter.prototype.getMainView = function(views) {
   });
 };
 
-/*
+/**
  * Proxy to Backbone.Router.
  */
 ClientRouter.prototype.navigate = function(path, options) {

--- a/server/data_adapter/rest_adapter.js
+++ b/server/data_adapter/rest_adapter.js
@@ -1,10 +1,10 @@
-var DataAdapter = require('./index')
-  , utils = require('../utils')
-  , _ = require('underscore')
-  , url = require('url')
-  , request = require('request')
-  , debug = require('debug')('rendr:RestAdapter')
-  , util = require('util');
+var DataAdapter = require('./index'),
+    utils = require('../utils'),
+    _ = require('underscore'),
+    url = require('url'),
+    request = require('request'),
+    debug = require('debug')('rendr:RestAdapter'),
+    util = require('util');
 
 module.exports = RestAdapter;
 
@@ -60,8 +60,8 @@ RestAdapter.prototype.request = function(req, api, options, callback) {
   /**
    * Request timing.
    */
-  var start = new Date().getTime()
-    , end;
+  var start = new Date().getTime(),
+      end;
 
   /**
    * Make the request. The `api` object is passed into the `request` library.
@@ -149,8 +149,8 @@ RestAdapter.prototype.apiDefaults = function(api, req) {
  * Convert 4xx, 5xx responses to be errors.
  */
 RestAdapter.prototype.getErrForResponse = function(res, options) {
-  var status = +res.statusCode
-    , err = null;
+  var status = +res.statusCode,
+      err = null;
 
   if (utils.isErrorStatus(status, options)) {
     err = new Error(status + " status");

--- a/server/middleware/index.js
+++ b/server/middleware/index.js
@@ -1,9 +1,7 @@
-var fs, path;
+var fs = require('fs'),
+    path = require('path');
 
-fs = require('fs');
-path = require('path');
-
-/*
+/**
  * Set up each middleware file in this directory as a property
  * on exports. This means you can require this file and access
  * each middleware like so:

--- a/server/router.js
+++ b/server/router.js
@@ -1,9 +1,7 @@
-var BaseRouter, ServerRouter, ExpressRouter, sanitizer, _;
-
-_ = require('underscore');
-BaseRouter = require('../shared/base/router');
-ExpressRouter = require('express').Router;
-sanitizer = require('sanitizer');
+var _ = require('underscore'),
+    BaseRouter = require('../shared/base/router'),
+    ExpressRouter = require('express').Router,
+    sanitizer = require('sanitizer');
 
 module.exports = ServerRouter;
 
@@ -47,10 +45,11 @@ ServerRouter.prototype.getHandler = function(action, pattern, route) {
   var router = this;
 
   return function(req, res, next) {
-    var app, context, params, redirect;
+    var params = router.getParams(req),
+        redirect = router.getRedirect(route, params),
+        app = req.rendrApp,
+        context;
 
-    params = router.getParams(req);
-    redirect = router.getRedirect(route, params);
     /**
      * If `redirect` is present, then do a redirect and return.
      */
@@ -59,7 +58,6 @@ ServerRouter.prototype.getHandler = function(action, pattern, route) {
       return;
     }
 
-    app = req.rendrApp;
     context = {
       currentRoute: route,
       app: app,
@@ -77,7 +75,8 @@ ServerRouter.prototype.getHandler = function(action, pattern, route) {
       if (err) return next(err);
 
       var defaults = router.defaultHandlerParams(viewPath, locals, route);
-      viewPath = defaults[0], locals = defaults[1];
+      viewPath = defaults[0];
+      locals = defaults[1];
 
       var viewData = {
         locals: locals || {},

--- a/server/server.js
+++ b/server/server.js
@@ -1,9 +1,9 @@
-var _ = require('underscore')
-  , express = require('express')
-  , Router = require('./router')
-  , RestAdapter = require('./data_adapter/rest_adapter')
-  , ViewEngine = require('./viewEngine')
-  , middleware = require('./middleware');
+var _ = require('underscore'),
+    express = require('express'),
+    Router = require('./router'),
+    RestAdapter = require('./data_adapter/rest_adapter'),
+    ViewEngine = require('./viewEngine'),
+    middleware = require('./middleware');
 
 module.exports = Server;
 
@@ -28,15 +28,17 @@ function defaultOptions() {
 
 function Server(options) {
   if (typeof rendr !== 'undefined' && rendr.entryPath) {
-    console.warn("Setting rendr.entryPath is now deprecated. Please pass in entryPath when initializing the rendr server.")
+    console.warn("Setting rendr.entryPath is now deprecated. Please pass in \
+                 entryPath when initializing the rendr server.");
     options.entryPath = rendr.entryPath;
   }
+
   this.options = options || {};
   _.defaults(this.options, defaultOptions());
 
   this.expressApp = express();
 
-  this.dataAdapter = this.options.dataAdapter || new RestAdapter(this.options.dataAdapterConfig);;
+  this.dataAdapter = this.options.dataAdapter || new RestAdapter(this.options.dataAdapterConfig);
 
   this.viewEngine = this.options.viewEngine || new ViewEngine();
 
@@ -76,9 +78,9 @@ function Server(options) {
  * Pass `fn` in order to add custom middleware that should access `req.rendrApp`.
  */
 Server.prototype.configure = function(fn) {
-  var dataAdapter = this.dataAdapter
-    , apiPath = this.options.apiPath
-    , notApiRegExp = new RegExp('^(?!' + apiPath.replace('/', '\\/') + '\\/)');
+  var dataAdapter = this.dataAdapter,
+      apiPath = this.options.apiPath,
+      notApiRegExp = new RegExp('^(?!' + apiPath.replace('/', '\\/') + '\\/)');
 
   this._configured = true;
 
@@ -137,13 +139,12 @@ Server.prototype.configure = function(fn) {
 };
 
 Server.prototype.buildRoutes = function() {
-  var routes, pattern, route, handler;
+  var routes = this.router.buildRoutes();
 
-  routes = this.router.buildRoutes();
   routes.forEach(function(args) {
-    pattern = args[0];
-    route = args[1];
-    handler = args[2];
+    var pattern = args[0],
+        route = args[1],
+        handler = args[2];
 
     // Attach the route to the Express server.
     this.expressApp.get(pattern, handler);

--- a/server/viewEngine.js
+++ b/server/viewEngine.js
@@ -1,6 +1,6 @@
-var path = require('path')
-  , _ = require('underscore')
-  , layoutTemplates = {};
+var path = require('path'),
+    _ = require('underscore'),
+    layoutTemplates = {};
 
 module.exports = exports = ViewEngine;
 
@@ -55,10 +55,12 @@ ViewEngine.prototype.getLayoutTemplate = function getLayoutTemplate(app, callbac
 };
 
 ViewEngine.prototype.getViewHtml = function getViewHtml(viewPath, locals, app) {
-  var BaseView, View, name, view, basePath;
+  var basePath = path.join('app', 'views'),
+      BaseView = require('../shared/base/view'),
+      name,
+      View,
+      view;
 
-  basePath = path.join('app', 'views');
-  BaseView = require('../shared/base/view');
   locals = _.clone(locals);
 
   // Pass in the app.

--- a/shared/app.js
+++ b/shared/app.js
@@ -3,12 +3,11 @@
  * The client also subclasses it for client-specific stuff.
  */
 
-var Backbone, ClientRouter, Fetcher, ModelUtils, isServer;
-
-Backbone = require('backbone');
-Fetcher = require('./fetcher');
-ModelUtils = require('./modelUtils');
-isServer = (typeof window === 'undefined');
+var Backbone = require('backbone'),
+    Fetcher = require('./fetcher'),
+    ModelUtils = require('./modelUtils'),
+    isServer = (typeof window === 'undefined'),
+    ClientRouter;
 
 if (!isServer) {
   ClientRouter = require('app/router');

--- a/shared/base/collection.js
+++ b/shared/base/collection.js
@@ -1,10 +1,9 @@
-var _ = require('underscore')
-  , Backbone = require('backbone')
-  , syncer = require('../syncer')
-  , BaseModel = require('./model')
-  , Super = Backbone.Collection
-  , isServer = (typeof window === 'undefined')
-;
+var _ = require('underscore'),
+    Backbone = require('backbone'),
+    syncer = require('../syncer'),
+    BaseModel = require('./model'),
+    Super = Backbone.Collection,
+    isServer = (typeof window === 'undefined');
 
 if (!isServer) {
   Backbone.$ = window.$ || require('jquery');

--- a/shared/base/model.js
+++ b/shared/base/model.js
@@ -1,8 +1,7 @@
-var _ = require('underscore')
-  , Backbone = require('backbone')
-  , syncer = require('../syncer')
-  , isServer = (typeof window === 'undefined')
-;
+var _ = require('underscore'),
+    Backbone = require('backbone'),
+    syncer = require('../syncer'),
+    isServer = (typeof window === 'undefined');
 
 if (!isServer) {
   Backbone.$ = window.$ || require('jquery');

--- a/shared/base/router.js
+++ b/shared/base/router.js
@@ -1,8 +1,6 @@
-var Backbone, BaseRouter, noop, _, isServer;
-
-_ = require('underscore');
-Backbone = require('backbone');
-isServer = (typeof window === 'undefined');
+var _ = require('underscore'),
+    Backbone = require('backbone'),
+    isServer = (typeof window === 'undefined');
 
 if (!isServer) {
   Backbone.$ = window.$ || require('jquery');
@@ -52,8 +50,9 @@ BaseRouter.prototype._initOptions = function(options) {
 };
 
 BaseRouter.prototype.getController = function(controllerName) {
-  var controllerDir = this.options.paths.controllerDir
-    , controller, controllerPath;
+  var controllerDir = this.options.paths.controllerDir,
+      controller,
+      controllerPath;
 
   // preload all controllers on the server or in non-AMD env
   // for requirejs return path that will be lazy loaded
@@ -105,8 +104,8 @@ BaseRouter.prototype.getRedirect = function(route, params) {
  * Build route definitions based on the routes file.
  */
 BaseRouter.prototype.buildRoutes = function() {
-  var routeBuilder = require(this.options.paths.routes)
-    , routes = [];
+  var routeBuilder = require(this.options.paths.routes),
+      routes = [];
 
   function captureRoutes() {
     routes.push(_.toArray(arguments));
@@ -140,11 +139,11 @@ BaseRouter.prototype.routes = function() {
  * Adds a single route definition.
  */
 BaseRouter.prototype.route = function(pattern) {
-  var action, definitions, handler, route, routeObj;
-
-  definitions = _.toArray(arguments).slice(1);
-  route = this.parseDefinitions(definitions);
-  action = this.getAction(route);
+  var definitions = _.toArray(arguments).slice(1),
+      route = this.parseDefinitions(definitions),
+      action = this.getAction(route),
+      handler,
+      routeObj;
 
   if (!(pattern instanceof RegExp) && pattern.slice(0, 1) !== '/') {
     pattern = "/" + pattern;
@@ -158,9 +157,8 @@ BaseRouter.prototype.route = function(pattern) {
 };
 
 BaseRouter.prototype.parseDefinitions = function(definitions) {
-  var route;
+  var route = {};
 
-  route = {};
   definitions.forEach(function(element) {
     var parts;
 

--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -1,14 +1,15 @@
-// Since we make rendr files AMD friendly on app setup stage
-// we need to pretend that this code is pure commonjs
-// means no AMD-style require calls
+/**
+ * Since we make rendr files AMD friendly on app setup stage
+ * we need to pretend that this code is pure commonjs
+ * means no AMD-style require calls
+ */
 var requireAMD = require;
 
-var Backbone, BaseView, _, async;
-
-_ = require('underscore');
-Backbone = require('backbone');
-async = require('async');
-isServer = (typeof window === 'undefined');
+var _ = require('underscore'),
+    Backbone = require('backbone'),
+    async = require('async'),
+    isServer = (typeof window === 'undefined'),
+    BaseView;
 
 if (!isServer) {
   Backbone.$ = window.$ || require('jquery');
@@ -160,7 +161,9 @@ module.exports = BaseView = Backbone.View.extend({
    * Get HTML attributes to add to el.
    */
   getAttributes: function() {
-    var attributes = {}, fetchSummary = {}, modelUtils = this.app.modelUtils;
+    var attributes = {},
+        fetchSummary = {},
+        modelUtils = this.app.modelUtils;
 
     if (this.attributes) {
       _.extend(attributes, _.result(this, 'attributes'));
@@ -218,12 +221,12 @@ module.exports = BaseView = Backbone.View.extend({
    * Turn template into HTML, minus the wrapper element.
    */
   getInnerHtml: function() {
-    var data, template;
+    var template = this.getTemplate(),
+        data;
 
     this._preRender();
     data = this.getTemplateData();
     data = this.decorateTemplateData(data);
-    template = this.getTemplate();
     if (template == null) {
       throw new Error(this.name + ": template \"" + this.getTemplateName() + "\" not found.");
     }
@@ -234,21 +237,20 @@ module.exports = BaseView = Backbone.View.extend({
    * Get the HTML for the view, including the wrapper element.
    */
   getHtml: function() {
-    var attrString, attributes, html, tagName;
+    var html = this.getInnerHtml(),
+        attributes = this.getAttributes(),
+        tagName = _.result(this, "tagName"),
+        attrString;
 
-    html = this.getInnerHtml();
-    attributes = this.getAttributes();
     attrString = _.inject(attributes, function(memo, value, key) {
       return memo += " " + key + "=\"" + _.escape(value) + "\"";
     }, '');
-    tagName = _.result(this, "tagName");
+
     return "<" + tagName + attrString + ">" + html + "</" + tagName + ">";
   },
 
   render: function() {
-    var html;
-
-    html = this.getInnerHtml();
+    var html = this.getInnerHtml();
     this.$el.html(html);
 
     // Because we only set the attributes of the outer element
@@ -265,9 +267,9 @@ module.exports = BaseView = Backbone.View.extend({
    * fetch it based on the parameters passed in.
    */
   fetchLazy: function() {
-    var fetchSpec, params;
+    var params = {},
+        fetchSpec;
 
-    params = {};
     params[this.options.param_name] = this.options.param_value;
     if (this.options.model_id != null) {
       params.id = this.options.model_id;
@@ -361,9 +363,7 @@ module.exports = BaseView = Backbone.View.extend({
    * this is what gets called to bind to the element.
    */
   attach: function(element, parentView) {
-    var $el;
-
-    $el = $(element);
+    var $el = $(element);
     $el.data('view-attached', true);
     this.setElement($el);
 
@@ -471,10 +471,8 @@ BaseView.getView = function(viewName, entryPath, callback) {
 };
 
 BaseView.attach = function(app, parentView, callback) {
-  var scope, list;
-  scope = parentView != null ? parentView.$el : null;
-
-  list = $('[data-view]', scope).toArray();
+  var scope = parentView ? parentView.$el : null,
+      list = $('[data-view]', scope).toArray();
 
   async.map(list, function(el, cb) {
     var $el, options, parsed, viewName;

--- a/shared/modelUtils.js
+++ b/shared/modelUtils.js
@@ -1,138 +1,132 @@
-// Since we make rendr files AMD friendly on app setup stage
-// we need to pretend that this code is pure commonjs
-// means no AMD-style require calls
+/**
+ * Since we make rendr files AMD friendly on app setup stage
+ * we need to pretend that this code is pure commonjs
+ * means no AMD-style require calls.
+ */
 var requireAMD = require;
+
+var BaseModel = require("./base/model"),
+    BaseCollection = require("./base/collection");
 
 var typePath = {
   model: "app/models/",
   collection: "app/collections/"
 };
 
-var BaseCollection, BaseModel, ModelUtils;
+module.exports = ModelUtils;
 
-BaseModel = require("./base/model");
+function ModelUtils(entryPath) {
+  this.entryPath = entryPath;
+  this._classMap = {};
+}
 
-BaseCollection = require("./base/collection");
-
-module.exports = ModelUtils = (function() {
-  function ModelUtils(entryPath) {
-    this.entryPath = entryPath;
-    this._classMap = {};
+ModelUtils.prototype.getModel = function(path, attrs, options, callback) {
+  var Model;
+  attrs = attrs || {};
+  options = options || {};
+  if (typeof callback == 'function') {
+    this.getModelConstructor(path, function(Model) {
+      callback(new Model(attrs, options));
+    });
+  } else {
+    Model = this.getModelConstructor(path);
+    return new Model(attrs, options);
   }
+};
 
-  ModelUtils.prototype.getModel = function(path, attrs, options, callback) {
-    var Model;
-    attrs = attrs || {};
-    options = options || {};
-    if (typeof callback == 'function') {
-      this.getModelConstructor(path, function(Model) {
-        callback(new Model(attrs, options));
-      });
-    } else {
-      Model = this.getModelConstructor(path);
-      return new Model(attrs, options);
-    }
-  };
-
-  ModelUtils.prototype.getCollection = function(path, models, options, callback) {
-    var Collection;
-    models = models || [];
-    options = options || {};
-    if (typeof callback == 'function') {
-      this.getCollectionConstructor(path, function(Collection) {
-        callback(new Collection(models, options));
-      });
-    } else {
-      Collection = this.getCollectionConstructor(path);
-      return new Collection(models, options);
-    }
-  };
-
-  ModelUtils.prototype.getModelConstructor = function(path, callback) {
-    return this.fetchConstructor('model', path, callback);
-  };
-
-  ModelUtils.prototype.getCollectionConstructor = function(path, callback) {
-    return this.fetchConstructor('collection', path, callback);
-  };
-
-  ModelUtils.prototype.fetchConstructor = function(type, path, callback) {
-    path = this.underscorize(path);
-
-    var fullPath = this.entryPath + typePath[type] + path;
-
-    if (this._classMap[path]) {
-      return (typeof callback == 'function') ? callback(this._classMap[path]) : this._classMap[path];
-    } else if (typeof callback == 'function') {
-      // Only used in AMD environment
-      if (typeof define != 'undefined') {
-        requireAMD([fullPath], callback);
-      } else {
-        callback(require(fullPath));
-      }
-      return;
-    } else {
-      return require(fullPath);
-    }
-  };
-
-  ModelUtils.prototype.isModel = function(obj) {
-    return obj instanceof BaseModel;
-  };
-
-  ModelUtils.prototype.isCollection = function(obj) {
-    return obj instanceof BaseCollection;
-  };
-
-  ModelUtils.prototype.getModelNameForCollectionName = function(collectionName) {
-    var Collection;
-    Collection = this.getCollectionConstructor(collectionName);
-    return this.modelName(Collection.prototype.model);
-  };
-
-  ModelUtils.uppercaseRe = /([A-Z])/g;
-
-  ModelUtils.prototype.underscorize = function(name) {
-    if (name == null) {
-      return undefined;
-    }
-    name = name.replace(ModelUtils.uppercaseRe, function(c) {
-      return "_" + c.toLowerCase();
+ModelUtils.prototype.getCollection = function(path, models, options, callback) {
+  var Collection;
+  models = models || [];
+  options = options || {};
+  if (typeof callback == 'function') {
+    this.getCollectionConstructor(path, function(Collection) {
+      callback(new Collection(models, options));
     });
-    if (name[0] === "_") {
-      name = name.slice(1);
+  } else {
+    Collection = this.getCollectionConstructor(path);
+    return new Collection(models, options);
+  }
+};
+
+ModelUtils.prototype.getModelConstructor = function(path, callback) {
+  return this.fetchConstructor('model', path, callback);
+};
+
+ModelUtils.prototype.getCollectionConstructor = function(path, callback) {
+  return this.fetchConstructor('collection', path, callback);
+};
+
+ModelUtils.prototype.fetchConstructor = function(type, path, callback) {
+  path = this.underscorize(path);
+
+  var fullPath = this.entryPath + typePath[type] + path;
+
+  if (this._classMap[path]) {
+    return (typeof callback == 'function') ? callback(this._classMap[path]) : this._classMap[path];
+  } else if (typeof callback == 'function') {
+    // Only used in AMD environment
+    if (typeof define != 'undefined') {
+      requireAMD([fullPath], callback);
+    } else {
+      callback(require(fullPath));
     }
-    return name;
-  };
+    return;
+  } else {
+    return require(fullPath);
+  }
+};
 
-  /*
-  The 'name' property is added to the constructor when using a named function,
-  and it cannot be changed.  I.e.:
+ModelUtils.prototype.isModel = function(obj) {
+  return obj instanceof BaseModel;
+};
 
-  function MyClass(){}
-  MyClass.name
-  -> "MyClass"
+ModelUtils.prototype.isCollection = function(obj) {
+  return obj instanceof BaseCollection;
+};
 
-  We first look for the 'id' property of the constructor, which is compatible
-  with standard Backbone-style class inheritance.
+ModelUtils.prototype.getModelNameForCollectionName = function(collectionName) {
+  var Collection;
+  Collection = this.getCollectionConstructor(collectionName);
+  return this.modelName(Collection.prototype.model);
+};
 
-  var MyClass = Backbone.Model.extend({});
-  MyClass.name
-  -> ""
-  MyClass.id = "MyClass"
-  */
+ModelUtils.uppercaseRe = /([A-Z])/g;
 
+ModelUtils.prototype.underscorize = function(name) {
+  if (name == null) {
+    return undefined;
+  }
+  name = name.replace(ModelUtils.uppercaseRe, function(c) {
+    return "_" + c.toLowerCase();
+  });
+  if (name[0] === "_") {
+    name = name.slice(1);
+  }
+  return name;
+};
 
-  ModelUtils.prototype.modelName = function(modelOrCollectionClass) {
-    return this.underscorize(modelOrCollectionClass.id || modelOrCollectionClass.name);
-  };
+/**
+ * The 'name' property is added to the constructor when using a named function,
+ * and it cannot be changed.  I.e.:
+ *
+ * function MyClass(){}
+ * MyClass.name
+ * -> "MyClass"
+ *
+ * We first look for the 'id' property of the constructor, which is compatible
+ * with standard Backbone-style class inheritance.
+ *
+ * var MyClass = Backbone.Model.extend({});
+ * MyClass.name
+ * -> ""
+ * MyClass.id = "MyClass"
+ */
+ModelUtils.prototype.modelName = function(modelOrCollectionClass) {
+  return this.underscorize(modelOrCollectionClass.id || modelOrCollectionClass.name);
+};
 
-  ModelUtils.prototype.modelIdAttribute = function(modelName, callback) {
-    this.getModelConstructor(modelName, function(constructor) {
-      callback(constructor.prototype.idAttribute);
-    });
-  };
-
-  return ModelUtils;
-
-})();
+ModelUtils.prototype.modelIdAttribute = function(modelName, callback) {
+  this.getModelConstructor(modelName, function(constructor) {
+    callback(constructor.prototype.idAttribute);
+  });
+};

--- a/shared/store/collection_store.js
+++ b/shared/store/collection_store.js
@@ -1,7 +1,5 @@
-var MemoryStore, Super, _;
-
-_ = require('underscore');
-Super = MemoryStore = require('./memory_store');
+var _ = require('underscore'),
+    Super = require('./memory_store');
 
 module.exports = CollectionStore;
 
@@ -28,15 +26,15 @@ CollectionStore.prototype.set = function(collection, params) {
   return Super.prototype.set.call(this, key, data, null);
 };
 
-/*
-* Returns an array of model ids.
-*/
+/**
+ * Returns an array of model ids.
+ */
 CollectionStore.prototype.get = function(collectionName, params, callback) {
   var _collectionStore = this;
-  /*
-  * Kind of jank-sauce. Always merge in the default
-  * params for the given collection.
-  */
+  /**
+   * Kind of jank-sauce. Always merge in the default
+   * params for the given collection.
+   */
   if (typeof callback == 'function') {
     this.modelUtils.getCollectionConstructor(collectionName, function(Collection) {
       callback(get.call(_collectionStore, collectionName, params, Collection));
@@ -61,8 +59,7 @@ CollectionStore.prototype._formatKey = function(key) {
 };
 
 CollectionStore.prototype._getStoreKey = function(collectionName, params) {
-  var underscored;
-  underscored = this.modelUtils.underscorize(collectionName);
+  var underscored = this.modelUtils.underscorize(collectionName);
   return underscored + ":" + JSON.stringify(sortParams(params));
 }
 

--- a/shared/store/model_store.js
+++ b/shared/store/model_store.js
@@ -1,7 +1,5 @@
-var MemoryStore, Super, _;
-
-_ = require('underscore');
-Super = MemoryStore = require('./memory_store');
+var _ = require('underscore'),
+    Super = require('./memory_store');
 
 module.exports = ModelStore;
 
@@ -25,10 +23,10 @@ ModelStore.prototype.set = function(model) {
   }
   key = this._getModelStoreKey(modelName, id);
 
-  /*
-  * We want to merge the model attrs with whatever is already
-  * present in the store.
-  */
+  /**
+   * We want to merge the model attrs with whatever is already
+   * present in the store.
+   */
   existingAttrs = this.get(modelName, id) || {};
   newAttrs = _.extend({}, existingAttrs, model.toJSON());
   return Super.prototype.set.call(this, key, newAttrs, null);

--- a/shared/syncer.js
+++ b/shared/syncer.js
@@ -4,21 +4,20 @@
  * for fetching data from the API.
  */
 
-var _ = require('underscore')
-  , Backbone = require('backbone')
+var _ = require('underscore'),
+    Backbone = require('backbone'),
 
-  // Pull out params in path, like '/users/:id'.
-  , extractParamNamesRe = /:([a-z_-]+)/ig
+    // Pull out params in path, like '/users/:id'.
+    extractParamNamesRe = /:([a-z_-]+)/ig,
 
-  , methodMap = {
-    'create': 'POST',
-    'update': 'PUT',
-    'delete': 'DELETE',
-    'read': 'GET'
-  }
+    methodMap = {
+      'create': 'POST',
+      'update': 'PUT',
+      'delete': 'DELETE',
+      'read': 'GET'
+    },
 
-  , isServer = (typeof window === 'undefined')
-;
+    isServer = (typeof window === 'undefined');
 
 if (isServer) {
   // hide it from requirejs since it's server only
@@ -40,14 +39,13 @@ function clientSync(method, model, options) {
   error = options.error;
   if (error) {
     options.error = function(xhr) {
-      var body, contentType, resp;
-      body = xhr.responseText;
-      contentType = xhr.getResponseHeader('content-type');
+      var body = xhr.responseText,
+          contentType = xhr.getResponseHeader('content-type'),
+          resp;
       if (contentType && contentType.indexOf('application/json') !== -1) {
         try {
           body = JSON.parse(body);
-        } catch (e) {
-        }
+        } catch (e) {}
       }
       resp = {
         body: body,
@@ -200,12 +198,15 @@ syncer.checkFresh = function checkFresh() {
  * Deeply-compare two objects to see if they differ.
  */
 syncer.objectsDiffer = function objectsDiffer(data1, data2) {
-  var changed, key, keys, value1, value2, _i, _len;
+  var changed = false,
+      keys,
+      key,
+      value1,
+      value2;
 
-  changed = false;
   keys = _.unique(_.keys(data1).concat(_.keys(data2)));
-  for (_i = 0, _len = keys.length; _i < _len; _i++) {
-    key = keys[_i];
+  for (var i = 0, len = keys.length; i < len; i++) {
+    key = keys[i];
     value1 = data1[key];
     value2 = data2[key];
 
@@ -225,15 +226,14 @@ syncer.objectsDiffer = function objectsDiffer(data1, data2) {
  * the model you supply has model.get('id') == 3.
  */
 syncer.interpolateParams = function interpolateParams(model, url, params) {
-  var matches;
+  var matches = url.match(extractParamNamesRe);
 
   params = params || {};
-  matches = url.match(extractParamNamesRe);
+
   if (matches) {
     matches.forEach(function(param) {
-      var property, value;
-
-      property = param.slice(1);
+      var property = param.slice(1),
+          value;
 
       // Is collection? Then use options.
       if (model.length != null) {

--- a/test/client/app_view.test.js
+++ b/test/client/app_view.test.js
@@ -1,10 +1,8 @@
-var App, AppView, should, clientTestHelper, $;
-
-App = require('../../shared/app');
-AppView = require('../../client/app_view');
-should = require('chai').should();
-clientTestHelper = require('../helpers/client_test');
-$ = require('jquery');
+var App = require('../../shared/app'),
+    AppView = require('../../client/app_view'),
+    should = require('chai').should(),
+    clientTestHelper = require('../helpers/client_test'),
+    $ = require('jquery');
 
 describe('AppView', function() {
   before(clientTestHelper.before);

--- a/test/client/router.test.js
+++ b/test/client/router.test.js
@@ -1,15 +1,12 @@
-var App, BaseView, AppViewClass, Router, should, routerConfig, clientTestHelper;
+var should = require('chai').should(),
+    App = require('../../shared/app'),
+    BaseView = require('../../shared/base/view'),
+    AppView = require('../../client/app_view'),
+    Router = require('../../client/router'),
+    clientTestHelper = require('../helpers/client_test'),
+    AppViewClass = require('../../client/app_view');
 
-should = require('chai').should();
-
-App = require('../../shared/app');
-BaseView = require('../../shared/base/view');
-AppView = require('../../client/app_view');
-Router = require('../../client/router');
-clientTestHelper = require('../helpers/client_test');
-AppViewClass = require('../../client/app_view');
-
-routerConfig = {
+var routerConfig = {
   app: new App({}, {}),
   appViewClass: AppViewClass,
   paths: {

--- a/test/helpers/add_class_mapping.js
+++ b/test/helpers/add_class_mapping.js
@@ -1,17 +1,11 @@
-var AddClassMapping, ModelUtils;
+var ModelUtils = require('../../shared/modelUtils');
 
-ModelUtils = require('../../shared/modelUtils');
+module.exports = AddClassMapping;
 
-module.exports = AddClassMapping = (function() {
-  function AddClassMapping(utils) {
-    this.utils = utils;
-    this.utils || (this.utils = new ModelUtils);
-  }
+function AddClassMapping(utils) {
+  this.utils = utils || new ModelUtils();
+}
 
-  AddClassMapping.prototype.add = function(key, modelConstructor) {
-    return this.utils._classMap[this.utils.underscorize(key)] = modelConstructor;
-  };
-
-  return AddClassMapping;
-
-})();
+AddClassMapping.prototype.add = function(key, modelConstructor) {
+  return this.utils._classMap[this.utils.underscorize(key)] = modelConstructor;
+};

--- a/test/helpers/client_test.js
+++ b/test/helpers/client_test.js
@@ -4,10 +4,8 @@
 //  before(clientTestHelper.before);
 //  after(clientTestHelper.after);
 
-var Backbone, BaseView;
-
-Backbone = require('backbone');
-BaseView = require('../../shared/base/view');
+var Backbone = require('backbone'),
+    BaseView = require('../../shared/base/view');
 
 exports.before = function(){
   this.originalBackbonejQuery = Backbone.$;

--- a/test/server/router.test.js
+++ b/test/server/router.test.js
@@ -1,16 +1,15 @@
 /*global describe, it, beforeEach */
 
-var Router, config, chai, should, express, _, sinon;
+var chai = require('chai'),
+    should = chai.should(),
+    Router = require('../../server/router'),
+    express = require('express'),
+    _ = require('underscore'),
+    sinon = require('sinon');
 
-chai = require('chai');
 chai.use(require('sinon-chai'));
-should = chai.should();
-Router = require('../../server/router');
-express = require('express');
-_ = require('underscore');
-sinon = require('sinon');
 
-config = {
+var config = {
   paths: {
     entryPath: __dirname + "/../fixtures/"
   }
@@ -30,8 +29,7 @@ describe("server/router", function() {
 
   describe("route", function() {
     it("should add basic route definitions", function() {
-      var route;
-      route = this.router.route("test", "test#index");
+      var route = this.router.route("test", "test#index");
       shouldMatchRoute(route, [
         '/test', {
           controller: 'test',
@@ -41,9 +39,7 @@ describe("server/router", function() {
     });
 
     it("should support leading slash in pattern", function() {
-      var route;
-
-      route = this.router.route("/test", "test#index");
+      var route = this.router.route("/test", "test#index");
       return shouldMatchRoute(route, [
         '/test', {
           controller: 'test',
@@ -53,9 +49,8 @@ describe("server/router", function() {
     });
 
     it("should support RegExp route definitions", function() {
-      var route
-        , routeRegex = /reg[ex]{2}ro(u|t)e?/;
-      route = this.router.route(routeRegex, "test#index");
+      var routeRegex = /reg[ex]{2}ro(u|t)e?/,
+          route = this.router.route(routeRegex, "test#index");
       shouldMatchRoute(route, [
         routeRegex, {
           controller: 'test',
@@ -65,9 +60,7 @@ describe("server/router", function() {
     });
 
     it("should support object as second argument", function() {
-      var route;
-
-      route = this.router.route("/test", {
+      var route = this.router.route("/test", {
         controller: 'test',
         action: 'index',
         role: 'admin'
@@ -82,9 +75,7 @@ describe("server/router", function() {
     });
 
     it("should support string as second argument, object as third argument", function() {
-      var route;
-
-      route = this.router.route("/test", "test#index", {
+      var route = this.router.route("/test", "test#index", {
         role: 'admin'
       });
       shouldMatchRoute(route, [
@@ -382,22 +373,22 @@ describe("server/router", function() {
           res = { render: sinon.spy(), redirect: sinon.spy() },
           handler;
 
-        handler = this.router.getHandler(function (params, callback) {
-          params.should.eql({ id: '1' });
-          this.currentRoute.should.equal(rendrRoute);
-          this.app.should.equal(rendrApp);
-          this.redirectTo.should.be.a('function');
-          callback(null, 'template/path', { some: 'data' });
-        }, this.pattern, rendrRoute);
+      handler = this.router.getHandler(function (params, callback) {
+        params.should.eql({ id: '1' });
+        this.currentRoute.should.equal(rendrRoute);
+        this.app.should.equal(rendrApp);
+        this.redirectTo.should.be.a('function');
+        callback(null, 'template/path', { some: 'data' });
+      }, this.pattern, rendrRoute);
 
-        handler(this.req, res);
+      handler(this.req, res);
 
-        res.render.should.have.been.calledOnce;
-        res.render.should.have.been.calledWith('template/path', {
-          locals: { some: 'data' },
-          app: this.req.rendrApp,
-          req: this.req
-        });
+      res.render.should.have.been.calledOnce;
+      res.render.should.have.been.calledWith('template/path', {
+        locals: { some: 'data' },
+        app: this.req.rendrApp,
+        req: this.req
+      });
     });
 
     describe('redirectTo', function () {
@@ -406,15 +397,15 @@ describe("server/router", function() {
             res = { redirect: sinon.spy() },
             handler;
 
-          handler = this.router.getHandler(function () {
-            this.redirectTo('/some_uri');
-          }, this.pattern, rendrRoute);
+        handler = this.router.getHandler(function () {
+          this.redirectTo('/some_uri');
+        }, this.pattern, rendrRoute);
 
-          handler(this.req, res);
+        handler(this.req, res);
 
-          res.redirect.should.have.been.calledOnce;
-          res.redirect.should.have.been.calledWithExactly('/some_uri');
-          res.redirect.should.have.been.calledOn(res);
+        res.redirect.should.have.been.calledOnce;
+        res.redirect.should.have.been.calledWithExactly('/some_uri');
+        res.redirect.should.have.been.calledOn(res);
       });
 
       it("should redirect to another page using a specific http status code", function () {
@@ -422,15 +413,15 @@ describe("server/router", function() {
             res = { redirect: sinon.spy() },
             handler;
 
-          handler = this.router.getHandler(function () {
-            this.redirectTo('/some_uri', {status: 301});
-          }, this.pattern, rendrRoute);
+        handler = this.router.getHandler(function () {
+          this.redirectTo('/some_uri', {status: 301});
+        }, this.pattern, rendrRoute);
 
-          handler(this.req, res);
+        handler(this.req, res);
 
-          res.redirect.should.have.been.calledOnce;
-          res.redirect.should.have.been.calledWithExactly(301, '/some_uri');
-          res.redirect.should.have.been.calledOn(res);
+        res.redirect.should.have.been.calledOnce;
+        res.redirect.should.have.been.calledWithExactly(301, '/some_uri');
+        res.redirect.should.have.been.calledOn(res);
       });
     });
   });

--- a/test/server/server.test.js
+++ b/test/server/server.test.js
@@ -1,7 +1,5 @@
-var Server, should;
-
-should = require('chai').should();
-Server = require('../../server/server');
+var should = require('chai').should(),
+    Server = require('../../server/server');
 
 describe("server/server", function() {
 

--- a/test/server/viewEngine.test.js
+++ b/test/server/viewEngine.test.js
@@ -1,7 +1,7 @@
-var should = require('chai').should()
-  , sinon = require('sinon')
-  , ViewEngine = require('../../server/viewEngine')
-  , BaseView = require('../../shared/base/view');
+var should = require('chai').should(),
+    sinon = require('sinon'),
+    ViewEngine = require('../../server/viewEngine'),
+    BaseView = require('../../shared/base/view');
 
 describe('ViewEngine', function() {
   var app, viewEngine;

--- a/test/shared/base/collection.test.js
+++ b/test/shared/base/collection.test.js
@@ -1,13 +1,10 @@
-var App, BaseCollection, BaseModel, ModelUtils, should, _, AddClassMapping;
-
-_ = require('underscore');
-should = require('chai').should();
-BaseCollection = require('../../../shared/base/collection');
-BaseModel = require('../../../shared/base/model');
-App = require('../../../shared/app');
-
-ModelUtils = require('../../../shared/modelUtils');
-AddClassMapping = require('../../helpers/add_class_mapping')
+var _ = require('underscore'),
+    should = require('chai').should(),
+    BaseCollection = require('../../../shared/base/collection'),
+    BaseModel = require('../../../shared/base/model'),
+    App = require('../../../shared/app'),
+    ModelUtils = require('../../../shared/modelUtils'),
+    AddClassMapping = require('../../helpers/add_class_mapping');
 
 describe('BaseCollection', function() {
   beforeEach(function() {

--- a/test/shared/base/model.test.js
+++ b/test/shared/base/model.test.js
@@ -1,11 +1,8 @@
-var App, BaseModel, modelUtils, should, addClassMapping;
-
-should = require('chai').should();
-BaseModel = require('../../../shared/base/model');
-modelUtils = require('../../../shared/modelUtils');
-App = require('../../../shared/app');
-addClassMapping = require('../../helpers/add_class_mapping')
-
+var should = require('chai').should(),
+    BaseModel = require('../../../shared/base/model'),
+    modelUtils = require('../../../shared/modelUtils'),
+    App = require('../../../shared/app'),
+    addClassMapping = require('../../helpers/add_class_mapping');
 
 describe('BaseModel', function() {
   beforeEach(function() {

--- a/test/shared/base/view.test.js
+++ b/test/shared/base/view.test.js
@@ -1,10 +1,8 @@
-var BaseView, should, sinon, ModelUtils, modelUtils;
-
-should = require('chai').should();
-sinon = require('sinon');
-BaseView = require('../../../shared/base/view');
-ModelUtils = require('../../../shared/modelUtils');
-modelUtils = new ModelUtils();
+var should = require('chai').should(),
+    sinon = require('sinon'),
+    BaseView = require('../../../shared/base/view'),
+    ModelUtils = require('../../../shared/modelUtils'),
+    modelUtils = new ModelUtils();
 
 describe('BaseView', function() {
   beforeEach(function() {

--- a/test/shared/fetcher.test.js
+++ b/test/shared/fetcher.test.js
@@ -1,24 +1,20 @@
-var App, Listing, Listings, BaseCollection, BaseModel, fetcher, listingResponses,
-  ModelUtils, modelUtils, sinon, chai, sinonChai, should, _, AddClassMapping, addClassMapping;
-
-_ = require('underscore');
-chai = require('chai');
-should = chai.should();
-sinon = require('sinon');
-sinonChai = require('sinon-chai');
-ModelUtils = require('../../shared/modelUtils');
-modelUtils = new ModelUtils()
-AddClassMapping = require('../helpers/add_class_mapping')
-addClassMapping = new AddClassMapping(modelUtils)
-BaseModel = require('../../shared/base/model');
-BaseCollection = require('../../shared/base/collection');
-App = require('../../shared/app');
+var _ = require('underscore'),
+    chai = require('chai'),
+    should = chai.should(),
+    sinon = require('sinon'),
+    sinonChai = require('sinon-chai'),
+    ModelUtils = require('../../shared/modelUtils'),
+    modelUtils = new ModelUtils(),
+    AddClassMapping = require('../helpers/add_class_mapping'),
+    addClassMapping = new AddClassMapping(modelUtils),
+    BaseModel = require('../../shared/base/model'),
+    BaseCollection = require('../../shared/base/collection'),
+    App = require('../../shared/app'),
+    fetcher = null;
 
 chai.use(sinonChai);
 
-fetcher = null;
-
-listingResponses = {
+var listingResponses = {
   basic: {
     name: 'Fetching!'
   },
@@ -28,7 +24,7 @@ listingResponses = {
   }
 };
 
-Listing = BaseModel.extend({
+var Listing = BaseModel.extend({
   jsonKey: 'listing',
 
   fetch: function(options) {
@@ -45,7 +41,7 @@ Listing = BaseModel.extend({
 });
 Listing.id = 'Listing';
 
-Listings = BaseCollection.extend({
+var Listings = BaseCollection.extend({
   model: Listing,
   jsonKey: 'listings',
 

--- a/test/shared/store/collection_store.test.js
+++ b/test/shared/store/collection_store.test.js
@@ -1,14 +1,12 @@
-var BaseCollection, BaseModel, CollectionStore, ModelUtils, modelUtils, should, util, AddClassMapping, addClassMapping;
-
-should = require('chai').should();
-util = require('util');
-CollectionStore = require('../../../shared/store/collection_store');
-BaseCollection = require('../../../shared/base/collection');
-BaseModel = require('../../../shared/base/model');
-ModelUtils = require('../../../shared/modelUtils');
-modelUtils = new ModelUtils()
-AddClassMapping = require('../../helpers/add_class_mapping')
-addClassMapping = new AddClassMapping(modelUtils)
+var should = require('chai').should(),
+    util = require('util'),
+    CollectionStore = require('../../../shared/store/collection_store'),
+    BaseCollection = require('../../../shared/base/collection'),
+    BaseModel = require('../../../shared/base/model'),
+    ModelUtils = require('../../../shared/modelUtils'),
+    modelUtils = new ModelUtils(),
+    AddClassMapping = require('../../helpers/add_class_mapping'),
+    addClassMapping = new AddClassMapping(modelUtils);
 
 addClassMapping.add(BaseCollection.name, BaseCollection);
 

--- a/test/shared/store/memory_store.test.js
+++ b/test/shared/store/memory_store.test.js
@@ -1,7 +1,5 @@
-var MemoryStore, should;
-
-MemoryStore = require('../../../shared/store/memory_store');
-should = require('chai').should();
+var MemoryStore = require('../../../shared/store/memory_store'),
+    should = require('chai').should();
 
 describe('MemoryStore', function() {
   beforeEach(function() {

--- a/test/shared/store/model_store.test.js
+++ b/test/shared/store/model_store.test.js
@@ -1,15 +1,12 @@
-var BaseModel, ModelStore, ModelUtils, modelUtils, should, _, util, AddClassMapping, addClassMapping;
-
-util = require('util');
-_ = require('underscore');
-should = require('chai').should();
-ModelStore = require('../../../shared/store/model_store');
-BaseModel = require('../../../shared/base/model');
-ModelUtils = require('../../../shared/modelUtils');
-modelUtils = new ModelUtils()
-AddClassMapping = require('../../helpers/add_class_mapping')
-addClassMapping = new AddClassMapping(modelUtils)
-
+var util = require('util'),
+    _ = require('underscore'),
+    should = require('chai').should(),
+    ModelStore = require('../../../shared/store/model_store'),
+    BaseModel = require('../../../shared/base/model'),
+    ModelUtils = require('../../../shared/modelUtils'),
+    modelUtils = new ModelUtils(),
+    AddClassMapping = require('../../helpers/add_class_mapping'),
+    addClassMapping = new AddClassMapping(modelUtils);
 
 function MyModel() {
   MyModel.super_.apply(this, arguments);

--- a/test/shared/syncer.test.js
+++ b/test/shared/syncer.test.js
@@ -1,9 +1,9 @@
-var _ = require('underscore')
-  , Backbone = require('backbone')
-  , should = require('chai').should()
-  , syncer = require('../../shared/syncer')
-  , BaseModel = require('../../shared/base/model')
-  , App = require('../../shared/app');
+var _ = require('underscore'),
+    Backbone = require('backbone'),
+    should = require('chai').should(),
+    syncer = require('../../shared/syncer'),
+    BaseModel = require('../../shared/base/model'),
+    App = require('../../shared/app');
 
 describe('syncer', function() {
 


### PR DESCRIPTION
In a fit of OCD, I went through the source files to standardize some
stylistic formatting. Most changes are to the `var` declarations at the
top of files. I.e., before:

```
var _, Backbone, BaseModel;

_ = require('underscore');
Backbone = require('backbone');
BaseModel = require('../shared/base/model');
```

After:

```
var _ = require('underscore'),
    Backbone = require('backbone'),
    BaseModel = require('../shared/base/model');
```

The original style of declaring `var` first was cruft leftover from the
original CoffeeScript codebase.

I also do a sweep of comment formatting for consistency.
