### PR TITLE
Preparing for release 0.5.0-rc1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,70 @@
+# 0.5.0
+## 2013-12-20
+* [breaking] Moved `AppView` to `client/` from `shared/`.
+* [breaking] Added support for AMD (RequireJS), which resulted in many methods
+  becoming asynchronous instead of synchronous (`Fetcher`, `BaseView`,
+  `ModelUtils`, etc.
+* [breaking] Removed global `entryPath`; no longer referencing `rendr` as a
+  global.
+* [breaking] Refactored server code to greatly reduce amount of boilerplate
+  needed to set up a Rendr app. Rendr now owns its own Express app, which can
+  be mounted on existing Express apps as a simple middleware.
+* [breaking] `server/server.js` now exports a class constructor rather than a
+  singleton.
+* [breaking] Removed unused `ServerRouter#stashError()` method.
+* [breaking] `modelUtils` object is now `ModelUtils` class.
+* Added `DataAdapter` base class and fleshed-out `RestAdapter`, which is the
+  default `DataAdapter` used by a Rendr server.
+* More flexibility with placement Rendr app files within an Express project.
+  app, and support for multiple Rendr apps in a single Express app.
+* Support passing `appAttributes` to `initApp` middleware as either object or
+  function, which takes `req` and `res` as arguments.
+* Added `viewing` property to `BaseView` for better introspection of current
+  view state.
+* Fix bug where collection params weren't properly passed to collections upon
+  view hydration.
+* Attach `req` to `App` instance on the server-side.
+* Switched default CommonJS packaging to Browserify from Stitch.
+* Added `examples/` dir, deprecating separate `rendr-app-template` project.
+* Fix bug where resources fetched by the `Fetcher` using spec keys other than
+  `model` or `collection` would be not hydrated properly by `BaseView`.
+* Don't intercept clicked links if 'shift' or 'meta' keys pressed.
+* Make it easier to use custom `AppView` class.
+* Add support for RegExp routes.
+* Only attempt to use `pushState` to redirect if the path matches one of the
+  app's routes.
+* Trigger `action:error` event in `ClientRouter` if there was an error caught
+  while running a controller's action.
+* Allow customizing the app's root path.
+* Added better support for `options.error` callback for `Backbone.sync()` in
+  the client-side.
+* Automatically add `X-Forwarded-For` header in `apiProxy` middleware.
+* Support using functions for `BaseView#id`, `BaseView#className`, and
+  `BaseView#tagName`.
+* Support passing `options.status` to `ServerRouter#redirectTo()`.
+* Use `sanitizer` module instead of un-maintained `validator` module for XSS
+  protection.
+* Update versions of dependencies: `underscore`, `qs`, `request`.
+* Much more unit tests.
+* Added Istanbul code coverage tool.
+
+# 0.4.10
+## 2013-08-02
+* Increment to bump `rendr-handlebars` version.
+
+# 0.4.9
+## 2013-07-27
+* Support multiple layout templates.
+
+# 0.4.8
+## 2013-07-26
+* Use `rendr-handlebars` module instead of `handlebars` module and utilize new
+  `templateAdapter` semantics (thanks @hurrymaplelad).
+* Fix XSS vulnerability in `ServerRouter#escapeParams()`.
+* Fix bug in `ServerRouter#getParams()`.
+* Change `viewEngine` module to be a class constructor `ViewEngine`.
+* Make sure to pass `app` instance to collections in `Fetcher#hydrate()`.
+
 # 0.4.7
 ## 2013-06-27
 * Fix for allowing port in absolute model URL.

--- a/examples/00_simple/package.json
+++ b/examples/00_simple/package.json
@@ -12,8 +12,8 @@
     "express": "~3",
     "underscore": "~1.4.4",
     "async": "~0.1.22",
-    "rendr-handlebars": "0.1.0",
-    "rendr": "0.5.0-alpha09"
+    "rendr-handlebars": "0.2.0-rc1",
+    "rendr": "0.5.0-rc1"
   },
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/examples/01_config/package.json
+++ b/examples/01_config/package.json
@@ -11,8 +11,8 @@
     "express": "~3",
     "underscore": "~1.4.4",
     "async": "~0.1.22",
-    "rendr-handlebars": "0.1.0",
-    "rendr": "0.5.0-alpha09",
+    "rendr-handlebars": "0.2.0-rc1",
+    "rendr": "0.5.0-rc1",
     "config": "~0.4.30",
     "js-yaml": "2.x.x"
   },

--- a/examples/02_middleware/package.json
+++ b/examples/02_middleware/package.json
@@ -11,8 +11,8 @@
     "express": "~3",
     "underscore": "~1.4.4",
     "async": "~0.1.22",
-    "rendr-handlebars": "0.1.0",
-    "rendr": "0.5.0-alpha09",
+    "rendr-handlebars": "0.2.0-rc1",
+    "rendr": "0.5.0-rc1",
     "config": "~0.4.30",
     "js-yaml": "2.x.x"
   },

--- a/examples/03_sessions/package.json
+++ b/examples/03_sessions/package.json
@@ -11,8 +11,8 @@
     "express": "~3",
     "underscore": "~1.4.4",
     "async": "~0.1.22",
-    "rendr-handlebars": "0.1.0",
-    "rendr": "0.5.0-alpha09",
+    "rendr-handlebars": "0.2.0-rc1",
+    "rendr": "0.5.0-rc1",
     "config": "~0.4.30",
     "js-yaml": "2.x.x"
   },

--- a/examples/04_entrypath/package.json
+++ b/examples/04_entrypath/package.json
@@ -11,8 +11,8 @@
     "express": "~3",
     "underscore": "~1.4.4",
     "async": "~0.1.22",
-    "rendr-handlebars": "0.1.0",
-    "rendr": "0.5.0-alpha09",
+    "rendr-handlebars": "0.2.0-rc1",
+    "rendr": "0.5.0-rc1",
     "config": "~0.4.30",
     "js-yaml": "2.x.x",
     "hbs": "~2.4.0"

--- a/examples/05_requirejs/package.json
+++ b/examples/05_requirejs/package.json
@@ -11,8 +11,8 @@
     "express": "~3",
     "underscore": "~1.4.4",
     "async": "~0.1.22",
-    "rendr-handlebars": "airbnb/rendr-handlebars#b204579aeea86bef27bb6c0a513bdb335c303558",
-    "rendr": "airbnb/rendr#99c34f75b5b10bc1efd194677341a652b8b2ad17",
+    "rendr-handlebars": "0.2.0-rc1",
+    "rendr": "0.5.0-rc1",
     "amdefine": "~0.1.0"
   },
   "devDependencies": {

--- a/examples/06_appview/package.json
+++ b/examples/06_appview/package.json
@@ -11,8 +11,8 @@
     "express": "~3",
     "underscore": "~1.4.4",
     "async": "~0.1.22",
-    "rendr-handlebars": "0.1.0",
-    "rendr": "0.5.0-alpha09"
+    "rendr-handlebars": "0.2.0-rc1",
+    "rendr": "0.5.0-rc1"
   },
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rendr",
-  "version": "0.5.0-alpha09",
+  "version": "0.5.0-rc1",
   "description": "Render your Backbone.js apps on the client and the server.",
   "main": "index.js",
   "scripts": {
@@ -30,7 +30,7 @@
     "sinon-chai": "2.4.0",
     "istanbul": "~0.1.10",
     "jquery": "~1.8.3",
-    "rendr-handlebars": "0.1.0"
+    "rendr-handlebars": "0.2.0-rc1"
   },
   "keywords": [
     "Backbone",


### PR DESCRIPTION
Updating versions in package.json of Rendr and of examples; updated
HISTORY.md.

We're very close to releasing 0.5.0!  The 0.5.0-rc1 release is just for testing that everything works well together (`rendr-handlebars`, etc.).
