### PR TITLE
add jshint configuration

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,87 @@
+module.exports = function(grunt) {
+  'use strict';
+
+  var _ = require('underscore'),
+      clientOptions, serverOptions, sharedOptions, testGlobals;
+
+  clientOptions = {
+    browser: true,
+    jquery: true,
+    node: false
+  };
+
+  serverOptions = {
+    browser: false,
+    jquery: false,
+    node: true
+  };
+
+  sharedOptions = {
+    browser: true,
+    jquery: true,
+    node: true
+  };
+
+  testGlobals = {
+    expect: true,
+    sinon: true,
+    describe: true,
+    it: true,
+    after: true,
+    afterEach: true,
+    before: true,
+    beforeEach: true
+  };
+
+  grunt.initConfig({
+    jshint: {
+      options: {
+        bitwise: true,
+        camelcase: true,
+        curly: true,
+        eqeqeq: true,
+        indent: 2,
+        newcap: true,
+        plusplus: false,
+        quotmark: 'single',
+        undef: true,
+        strict: true,
+        maxlen: 80
+      },
+
+      client: {
+        files: { src: [ 'client/**/*.js', 'test/client/**/*.js' ] },
+      },
+
+      clientTest: {
+        options: _.extend({}, clientOptions, { globals: testGlobals }),
+        files: { src: [ 'test/client/**/*.js' ] }
+      },
+
+      server: {
+        options: serverOptions,
+        files: { src: [ 'Gruntfile.js', 'index.js', 'server/**/*.js' ] },
+      },
+
+      serverTest: {
+        options: _.extend({}, serverOptions, { globals: testGlobals }),
+        files: { src: [ 'test/server/**/*.js' ] },
+        globals: testGlobals
+      },
+
+      shared: {
+        options: sharedOptions,
+        files: { src: [ 'shared/**/*.js'] }
+      },
+
+      sharedTest: {
+        options: _.extend({}, sharedOptions, { globals: testGlobals }),
+        files: { src: [ 'test/shared/**.js' ] }
+      }
+    }
+  });
+
+  grunt.loadNpmTasks('grunt-contrib-jshint');
+
+  grunt.registerTask('default', ['jshint']);
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "underscore": "1.5.2",
     "backbone": "1.0.0",
-    "async":"0.1.22",
+    "async": "0.1.22",
     "qs": "0.6.6",
     "express": "~3",
     "sanitizer": "~0.1",
@@ -30,7 +30,11 @@
     "sinon-chai": "2.4.0",
     "istanbul": "~0.1.10",
     "jquery": "~1.8.3",
-    "rendr-handlebars": "0.2.0-rc1"
+    "rendr-handlebars": "0.2.0-rc1",
+    "jshint": "2.3.0",
+    "grunt": "0.4.2",
+    "grunt-cli": "0.1.11",
+    "grunt-contrib-jshint": "0.7.2"
   },
   "keywords": [
     "Backbone",


### PR DESCRIPTION
the configuration tries to enforce as much as possible from the
airbnb/javascript style guide.

it is not yet enforced as part of the build in the package.json because there
are a lot of warnings and we should decide on all the options beforehand
