### PR TITLE
don't pass through headers from the incoming req

### DIFF
--- a/server/middleware/apiProxy.js
+++ b/server/middleware/apiProxy.js
@@ -20,8 +20,9 @@ function apiProxy(dataAdapter) {
 
     api.path = apiProxy.getApiPath(req.path);
     api.api = apiProxy.getApiName(req.path);
-    api.headers = apiProxy.addXForwardedForHeader(
-      req.headers, req.ip);
+    api.headers = {
+      'x-forwarded-for': apiProxy.getXForwardedForHeader(req.headers, req.ip)
+    };
 
     dataAdapter.request(req, api, {
       convertErrorCode: false
@@ -50,7 +51,7 @@ apiProxy.getApiName = function getApiName(path) {
   return apiName;
 };
 
-apiProxy.addXForwardedForHeader = function (headers, clientIp) {
+apiProxy.getXForwardedForHeader = function (headers, clientIp) {
   var existingHeader = headers['x-forwarded-for'],
       newHeaderValue = clientIp;
 
@@ -58,5 +59,5 @@ apiProxy.addXForwardedForHeader = function (headers, clientIp) {
     newHeaderValue = existingHeader + ', ' + clientIp;
   }
 
-  return _.extend({}, headers, {'x-forwarded-for': newHeaderValue});
+  return newHeaderValue;
 };

--- a/test/server/middleware/apiProxy.test.js
+++ b/test/server/middleware/apiProxy.test.js
@@ -11,7 +11,11 @@ describe('apiProxy', function() {
 
     beforeEach(function () {
       requestToApi = sinon.stub();
-      requestFromClient = { path: '/', headers: {}, connection: {} },
+      requestFromClient = {
+        path: '/',
+        headers: { 'host': 'any.host.name', },
+        connection: {}
+      },
       dataAdater = { request: requestToApi },
       proxy = apiProxy(dataAdater),
       responseToClient = { status: sinon.spy(), json: sinon.spy() };
@@ -66,6 +70,13 @@ describe('apiProxy', function() {
       outgoingHeaders['x-forwarded-for'].should.not.eq(
         incomingHeaders['x-forwarded-for']);
     });
+
+
+   it('should not pass through the host header', function () {
+      proxy(requestFromClient, responseToClient);
+      outgoingHeaders = requestToApi.firstCall.args[1].headers;
+      outgoingHeaders.should.not.contain.key('host');
+   });
 
   });
 


### PR DESCRIPTION
when implementing #228 I accidentally passed through all the headers by using
_.extend.

fixes #237: this bug was caused by passing through the `host` header, which
will lead to the api proxy trying to make an https request against the http
render app instead of the actually configured api host which expects the https
connection
