### PR TITLE
BaseRouter refactoring

### DIFF
--- a/shared/base/router.js
+++ b/shared/base/router.js
@@ -1,6 +1,8 @@
 var _ = require('underscore'),
-    Backbone = require('backbone'),
-    isServer = (typeof window === 'undefined');
+  Backbone = require('backbone'),
+  isServer = (typeof window === 'undefined'),
+  isAMDEnvironment = !isServer && (typeof define !== 'undefined'),
+  path = require('path');
 
 if (!isServer) {
   Backbone.$ = window.$ || require('jquery');
@@ -8,10 +10,25 @@ if (!isServer) {
 
 function noop() {}
 
-module.exports = BaseRouter;
+function stringRouteDefinitionToObject(element) {
+  var parts = element.split('#');
+  return {
+    controller: parts[0],
+    action: parts[1]
+  };
+}
+
+function parseRouteDefinitions(definitions) {
+  return definitions.reduce(function(route, element) {
+    if (_.isString(element)) {
+      element = stringRouteDefinitionToObject(element);
+    }
+    return _.extend(route, element);
+  }, {});
+}
 
 /**
- * Base router class shared betwen ClientRouter and ServerRouter.
+ * Base router class shared between ClientRouter and ServerRouter.
  */
 function BaseRouter(options) {
   this.route = this.route.bind(this);
@@ -20,189 +37,162 @@ function BaseRouter(options) {
   this.initialize(options);
 }
 
-/**
- * Config
- *   - errorHandler: function to correctly handle error
- *   - paths
- *     - entryPath (required)
- *     - routes (optional)
- *     - controllerDir (optional)
- */
-BaseRouter.prototype.options = null;
+_.extend(BaseRouter.prototype, Backbone.Events, {
+  /**
+   * Config
+   *   - errorHandler: function to correctly handle error
+   *   - paths
+   *     - entryPath (required)
+   *     - routes (optional)
+   *     - controllerDir (optional)
+   */
+  options: null,
 
-/**
- * Internally stored route definitions.
- */
-BaseRouter.prototype._routes = null;
+  /**
+   * Internally stored route definitions.
+   */
+  _routes: null,
 
-BaseRouter.prototype.reverseRoutes = false;
+  reverseRoutes: false,
 
-BaseRouter.prototype.initialize = function(options) {};
+  initialize: noop,
 
-BaseRouter.prototype._initOptions = function(options) {
-  var paths;
+  _initOptions: function(options) {
+    var entryPath;
 
-  this.options = options || {};
-  paths = this.options.paths = this.options.paths || {};
-  paths.entryPath = paths.entryPath || options.entryPath;
-  paths.routes = paths.routes || paths.entryPath + 'app/routes';
-  paths.controllerDir = paths.controllerDir || paths.entryPath + 'app/controllers';
-};
+    options = options || {};
+    options.paths = options.paths || {};
 
-BaseRouter.prototype.getController = function(controllerName) {
-  var controllerDir = this.options.paths.controllerDir,
-      controller,
-      controllerPath;
+    entryPath = options.paths.entryPath || options.entryPath;
+    options.paths = _.defaults(options.paths, {
+      entryPath: entryPath,
+      routes: path.join(entryPath, 'app/routes'),
+      controllerDir: path.join(entryPath, 'app/controllers')
+    });
 
-  // preload all controllers on the server or in non-AMD env
-  // for requirejs return path that will be lazy loaded
-  controllerPath = controllerDir + "/" + controllerName + "_controller";
+    this.options = options;
+  },
 
-  if (!isServer && typeof define !== 'undefined') {
-    controller = controllerPath;
-  } else {
-    controller = require(controllerPath);
-  }
+  getControllerPath: function(controllerName) {
+    var controllerDir = this.options.paths.controllerDir;
+    return path.join(controllerDir, controllerName + '_controller');
+  },
 
-  return controller;
-};
+  loadController: function(controllerName) {
+    var controllerPath = this.getControllerPath(controllerName);
+    return require(controllerPath);
+  },
 
-/**
- * Given an object with 'controller' and 'action' properties,
- * return the corresponding action function.
- */
-BaseRouter.prototype.getAction = function(route) {
-  var controller, action;
-  if (route.controller) {
-    controller = this.getController(route.controller);
-    if (typeof controller == 'object') {
-      action = controller[route.action];
+  getAction: function(route) {
+    var controller, action;
+
+    if (route.controller) {
+      if (isAMDEnvironment) {
+        action = this.getControllerPath(route.controller);
+      } else {
+        controller = this.loadController(route.controller);
+        action = controller[route.action];
+      }
     }
-    // In AMD environment controller is path string,
-    // which will be loaded when controller is needed.
-    else if (typeof controller == 'string') {
-      action = controller;
-    }
-  }
-  return action;
-};
 
-BaseRouter.prototype.getRedirect = function(route, params) {
-  var redirect = route.redirect;
-  if (redirect != null) {
-    /**
-     * Support function and string.
-     */
+    return action;
+  },
+
+  getRedirect: function(route, params) {
+    var redirect = route.redirect;
+
     if (typeof redirect === 'function') {
       redirect = redirect(params);
     }
-  }
-  return redirect;
-};
 
-/**
- * Build route definitions based on the routes file.
- */
-BaseRouter.prototype.buildRoutes = function() {
-  var routeBuilder = require(this.options.paths.routes),
+    return redirect;
+  },
+
+  getRouteBuilder: function() {
+    return require(this.options.paths.routes);
+  },
+
+  buildRoutes: function() {
+    var routeBuilder = this.getRouteBuilder(),
       routes = [];
 
-  function captureRoutes() {
-    routes.push(_.toArray(arguments));
-  }
+    function captureRoutes() {
+      routes.push(_.toArray(arguments));
+    }
 
-  try {
     routeBuilder(captureRoutes);
     if (this.reverseRoutes) {
       routes = routes.reverse();
     }
-    routes.forEach(function(route) {
+
+    routes.forEach(this.addRouteDefinition, this);
+
+    return this.routes();
+  },
+
+  addRouteDefinition: function(route) {
+    try {
       this.route.apply(this, route);
-    }, this);
-  } catch (e) {
-    throw new Error("Error building routes: " + e.stack);
-  }
-  return this.routes();
-};
-
-/**
- * Returns a copy of current route definitions.
- */
-BaseRouter.prototype.routes = function() {
-  return this._routes.slice().map(function(route) {
-    return route.slice();
-  });
-};
-
-/**
- * Method passed to routes file to build up routes definition.
- * Adds a single route definition.
- */
-BaseRouter.prototype.route = function(pattern) {
-  var definitions = _.toArray(arguments).slice(1),
-      route = this.parseDefinitions(definitions),
-      action = this.getAction(route),
-      handler,
-      routeObj;
-
-  if (!(pattern instanceof RegExp) && pattern.slice(0, 1) !== '/') {
-    pattern = "/" + pattern;
-  }
-
-  handler = this.getHandler(action, pattern, route);
-  routeObj = [pattern, route, handler];
-  this._routes.push(routeObj);
-  this.trigger('route:add', routeObj);
-  return routeObj;
-};
-
-BaseRouter.prototype.parseDefinitions = function(definitions) {
-  var route = {};
-
-  definitions.forEach(function(element) {
-    var parts;
-
-    /**
-     * Handle i.e. 'users#show'.
-     */
-    if (_.isString(element)) {
-      parts = element.split('#');
-      _.extend(route, {
-        controller: parts[0],
-        action: parts[1]
-      });
-    } else {
-      /**
-       * Handle objects ,i.e. {controller: 'users', action: 'show'}.
-       */
-      _.extend(route, element);
+    } catch (error) {
+      error.message = 'Error building routes (' + error.message + ')';
+      throw error;
     }
-  });
-  return route;
+  },
+
+  /**
+   * Returns a copy of current route definitions.
+   */
+  routes: function() {
+    return this._routes.slice().map(function(route) {
+      return route.slice();
+    });
+  },
+
+  /**
+   * Method passed to routes file to build up routes definition.
+   * Adds a single route definition.
+   */
+  route: function(pattern) {
+    var action, definitions, handler, route, routeObj;
+
+    definitions = _.toArray(arguments).slice(1);
+    route = parseRouteDefinitions(definitions);
+    action = this.getAction(route);
+
+    if (!(pattern instanceof RegExp) && pattern.slice(0, 1) !== '/') {
+      pattern = "/" + pattern;
+    }
+
+    handler = this.getHandler(action, pattern, route);
+    routeObj = [pattern, route, handler];
+    this._routes.push(routeObj);
+    this.trigger('route:add', routeObj);
+    return routeObj;
+  },
+
+  /**
+   * Support omitting view path; default it to ":controller/:action".
+   */
+  defaultHandlerParams: function(viewPath, locals, route) {
+    if (typeof viewPath !== 'string') {
+      locals = viewPath;
+      viewPath = route.controller + '/' + route.action;
+    }
+    return [viewPath, locals];
+  },
+
+  /**
+   * Methods to be extended by subclasses.
+   * -------------------------------------
+   */
+
+  /**
+   * This is the method that renders the request.
+   */
+  getHandler: noop
+});
+
+module.exports = BaseRouter;
+module.exports.setAMDEnvironment = function(flag) {
+  isAMDEnvironment = flag;
 };
-
-/**
- * Support omitting view path; default it to ":controller/:action".
- */
-BaseRouter.prototype.defaultHandlerParams = function(viewPath, locals, route) {
-  if (typeof viewPath !== 'string') {
-    locals = viewPath;
-    viewPath = route.controller + '/' + route.action;
-  }
-  return [viewPath, locals];
-};
-
-/**
- * Methods to be extended by subclasses.
- * -------------------------------------
- */
-
-/**
- * This is the method that renders the request.
- */
-BaseRouter.prototype.getHandler = noop;
-
-/**
- * Mix in Backbone.Events.
- */
-_.extend(BaseRouter.prototype, Backbone.Events);

--- a/test/shared/base/router.test.js
+++ b/test/shared/base/router.test.js
@@ -1,0 +1,154 @@
+var BaseRouter = require('../../../shared/base/router'),
+  sinon = require('sinon'),
+  chai = require('chai'),
+  should = chai.should();
+
+chai.use(require('sinon-chai'));
+
+describe('BaseRouter', function () {
+  describe('initialization', function () {
+    var testCases = [
+        {
+          options: { entryPath: 'foobar/' },
+          expectedOptions: {
+            entryPath: 'foobar/',
+            paths: {
+              entryPath: 'foobar/',
+              routes: 'foobar/app/routes',
+              controllerDir: 'foobar/app/controllers'
+            }
+          }
+        },
+        {
+          options: {
+            paths: {
+              entryPath: 'foobar/',
+              routes: '/some/other/location/MyRoutes.js',
+              controllerDir: 'another/different/location/'
+            }
+          },
+          expectedOptions: {
+            paths: {
+              entryPath: 'foobar/',
+              routes: '/some/other/location/MyRoutes.js',
+              controllerDir: 'another/different/location/'
+            }
+          }
+        },
+        {
+          options: { entryPath: 'foobar' },
+          expectedOptions: {
+            entryPath: 'foobar',
+            paths: {
+              entryPath: 'foobar',
+              routes: 'foobar/app/routes',
+              controllerDir: 'foobar/app/controllers'
+            }
+          }
+        }
+      ];
+
+    testCases.forEach(function(testCase) {
+      it('should initialize the paths options', function() {
+        var router = new BaseRouter(testCase.options);
+        router.options.should.be.deep.equal(testCase.expectedOptions);
+      });
+    });
+
+  });
+
+  describe('router instance', function() {
+    var router;
+
+    beforeEach(function() {
+      router = new BaseRouter({entryPath: 'MyAppRootPath/'});
+    });
+
+    describe('getAction', function () {
+      it('should return the controller path in AMD environment', function () {
+        var action;
+
+        BaseRouter.setAMDEnvironment(true);
+        action = router.getAction({controller: 'home'});
+
+        action.should.be.equal('MyAppRootPath/app/controllers/home_controller')
+        BaseRouter.setAMDEnvironment(false);
+      });
+
+      it('should load the controller in non AMD environments', function () {
+        var action,
+          controller = { index: sinon.spy() },
+          loadController = sinon.stub(router, 'loadController').returns(controller);
+
+        action = router.getAction({controller: 'home', action: 'index'});
+
+        loadController.should.have.been.calledOnce;
+        loadController.should.have.been.calledWith('home');
+        action.should.be.equal(controller.index);
+      });
+    });
+
+    describe('getRedirect', function() {
+      it('should return undefined if no redirect is given', function() {
+        var redirect = router.getRedirect({});
+        should.not.exist(redirect);
+      });
+
+      it('should return a string if the redirect is given as a string', function() {
+        var route = {redirect: '/home'},
+          redirect = router.getRedirect(route);
+
+        redirect.should.be.equal('/home');
+      });
+
+      it('should return the result of a given function', function() {
+        var params = {foo: 'bar'},
+          route = {redirect: function(params) {
+            return params.foo;
+          }},
+          redirect = router.getRedirect(route, params);
+
+        redirect.should.be.equal('bar');
+      });
+    });
+
+    describe('buildRoutes', function() {
+      it('should add route definitions', function () {
+        var getRouteBuilder = sinon.stub(router, 'getRouteBuilder'),
+          route = sinon.stub(router, 'route');
+
+        getRouteBuilder.returns(function (match) {
+          match('/foobar', 'foobar#index');
+        });
+        router.buildRoutes();
+
+        route.should.have.been.calledOnce;
+        route.should.have.been.calledWithExactly('/foobar', 'foobar#index');
+      });
+    });
+
+    describe('route', function() {
+      var action, handler, getAction, getHandler;
+
+      beforeEach(function() {
+        action = sinon.spy();
+        handler = sinon.spy();
+        getAction = sinon.stub(router, 'getAction').returns(action);
+        getHandler = sinon.stub(router, 'getHandler').returns(handler);
+      });
+
+      it('should trigger an event and pass the correct route object', function() {
+        var trigger = sinon.stub(router, 'trigger');
+
+        router.route('/home', 'home#index');
+
+        trigger.should.have.been.calledOnce;
+        trigger.should.have.been.calledWithExactly('route:add', [
+          '/home',
+          { controller: 'home', action: 'index' },
+          handler
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
I tried to replace the `Backbone.Router` with [page.js](http://visionmedia.github.io/page.js/) to have a `express`-compatible router on the client-side (#31).
 After digging into the code I realized that it is pretty hard to understand and hard to test. So I started to refactor the `BaseRouter` and write a test for it.
