### PR TITLE
Fix the 'Error: Cannot find module browserify'

### DIFF
--- a/examples/00_simple/package.json
+++ b/examples/00_simple/package.json
@@ -26,7 +26,8 @@
     "chai": "~1.8.1",
     "karma": "~0.10.4",
     "karma-chrome-launcher": "~0.1.0",
-    "karma-mocha": "~0.1.0"
+    "karma-mocha": "~0.1.0",
+    "browserify": "~3.14.1"
   },
   "engines": {
     "node": ">=0.8"


### PR DESCRIPTION
'Browserify' needs to be installed in order to run the example app.
