### PR TITLE
Fixes local modelStore not finding cached models

### DIFF
--- a/shared/fetcher.js
+++ b/shared/fetcher.js
@@ -173,7 +173,7 @@ Fetcher.prototype._retrieveModel = function(spec, callback) {
   var fetcher = this;
 
   // Attempt to fetch from the modelStore based on the idAttribute
-  this.modelUtils.modelIdAttribute(spec.model, function(err, idAttribute) {
+  this.modelUtils.modelIdAttribute(spec.model, function(idAttribute) {
     var modelData = fetcher.modelStore.get(spec.model, spec.params[idAttribute]);
     if (modelData)
       return callback(null, modelData);


### PR DESCRIPTION
modelIdAttribute doesn't callback with err,idAttribute, it only expects idAttribute.  This is causing the client-side model cache to always fail.
