### PR TITLE
fix serverSide redirectTo with rootPath != default

### DIFF
--- a/server/router.js
+++ b/server/router.js
@@ -67,6 +67,7 @@ ServerRouter.prototype.getHandler = function(action, pattern, route) {
       currentRoute: route,
       app: app,
       redirectTo: function(uri, options) {
+        uri = (app.get('rootPath') || '') + uri;
         if (options !== undefined && options.status) {
           res.redirect(options.status, uri);
         }

--- a/test/server/router.test.js
+++ b/test/server/router.test.js
@@ -431,6 +431,7 @@ describe("server/router", function() {
       beforeEach(function () {
         rendrRoute = { controller: 'users', action: 'show' },
         res = { redirect: sinon.spy() };
+        this.req.rendrApp.get = sinon.stub();
       });
 
       function createHandler(options) {
@@ -456,6 +457,18 @@ describe("server/router", function() {
         res.redirect.should.have.been.calledWithExactly(301, '/some_uri');
         res.redirect.should.have.been.calledOn(res);
       });
+
+      it("should redirect to the correct path with a rootPath set", function () {
+        var handler = createHandler();
+        this.req.rendrApp.get.withArgs('rootPath').returns('/myRoot');
+
+        handler(this.req, res);
+
+        res.redirect.should.have.been.calledOnce;
+        res.redirect.should.have.been.calledWithExactly('/myRoot/some_uri');
+        res.redirect.should.have.been.calledOn(res);
+      });
+
     });
   });
 });


### PR DESCRIPTION
When you set a rootPath on your rendrApp ('/myRoot', say), the client router will considers the configured `rootPath`, so that when you `redirectTo('/foo')` it will redirect to `/myRoot/foo`, while the current implementation of the server router would redirect to just `/foo`.
