### PR TITLE
Fixed binding error on _.each iterator

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -163,7 +163,8 @@ module.exports = BaseView = Backbone.View.extend({
   getAttributes: function() {
     var attributes = {},
         fetchSummary = {},
-        modelUtils = this.app.modelUtils;
+        modelUtils = this.app.modelUtils,
+        nonAttributeOptions = this.nonAttributeOptions;
 
     if (this.attributes) {
       _.extend(attributes, _.result(this, 'attributes'));
@@ -205,7 +206,7 @@ module.exports = BaseView = Backbone.View.extend({
             return;
           }
         }
-        if (!_.isObject(value) && !_.include(this.nonAttributeOptions, key)) {
+        if (!_.isObject(value) && !_.include(nonAttributeOptions, key)) {
           attributes["data-" + key] = value;
         }
       }


### PR DESCRIPTION
Originally this looked like: 

``` javascript
_.include(undefined, key)
```

This creates a crazy bug on iOS. It normally works, but on iOS _.include with undefined just hangs during rendering. I don't know if other's were experiencing this problem on iOS, but browsing just left a blank white page.

Now we're referencing nonAttributeOptions in the right context. 
