### PR TITLE
View-tech agnostic views, handlebars or ReactJS or others

### DIFF
--- a/client/app_view.js
+++ b/client/app_view.js
@@ -1,34 +1,38 @@
 var _ = require('underscore'),
-    Backbone = require('backbone'),
-    BaseView = require('../shared/base/view'),
     $ = (typeof window !== 'undefined' && window.$) || require('jquery');
 
-Backbone.$ = $;
+function AppView(options) {
 
-module.exports = BaseView.extend({
-  el: 'body',
+  this.options = options || {};
 
-  initialize: function() {
-    BaseView.prototype.initialize.apply(this, arguments);
+  _.defaults(this.options, {
+    el: 'body',
+    contentEl: '#content'
+  });
 
-    _.defaults(this.options, {
-      contentEl: '#content'
-    });
+  if( options.app != null ) {
+    this.app = this.options.app;
+  }
+  else {
+    throw new Error('options.app expected when creating a new AppView');
+  }
 
-    /**
-     * Grab the element that contains the main view.
-     */
-    this.$content = $(this.options.contentEl);
-    this._bindInterceptClick();
-  },
+  this.postInitialize();
+
+  this.$content = $(this.options.contentEl);
+  this.$el = $(this.options.el);
+  this._bindInterceptClick();
+}
+
+_.extend(AppView.prototype, {
+  postInitialize: function noop() {},
 
   hasPushState: typeof window !== "undefined" && window.history.pushState != null,
 
   render: function() {},
 
   setCurrentView: function(view) {
-    this.$content.html(view.el);
-    view.render();
+    view.renderInside(this.$content);
   },
 
   _bindInterceptClick: function() {
@@ -60,3 +64,5 @@ module.exports = BaseView.extend({
   }
 
 });
+
+module.exports = AppView;

--- a/client/router.js
+++ b/client/router.js
@@ -8,7 +8,6 @@ var requireAMD = require;
 var _ = require('underscore'),
     Backbone = require('backbone'),
     BaseRouter = require('../shared/base/router'),
-    BaseView = require('../shared/base/view'),
     $ = (typeof window !== 'undefined' && window.$) || require('jquery'),
     extractParamNamesRe = /:(\w+)/g,
     plusRe = /\+/g,
@@ -109,7 +108,7 @@ ClientRouter.prototype.getHandler = function(action, pattern, route) {
 
     if (firstRender) {
       firstRender = false;
-      BaseView.attach(router.app, null, function(views) {
+      router.app.viewAdapter.attach(router.app, null, function(views) {
         router.currentView = router.getMainView(views);
         router.trigger('action:end', route, true);
       });
@@ -150,9 +149,9 @@ ClientRouter.prototype.getHandler = function(action, pattern, route) {
  * if the initial render is more complicated.
  */
 ClientRouter.prototype.getMainView = function(views) {
-  var $content = this.appView.$content;
+  var contentNode = this.appView.$content.get(0);
   return _.find(views, function(view) {
-    return view.$el.parent().is($content);
+    return _.result(view, 'el').parentNode === contentNode;
   });
 };
 
@@ -287,7 +286,7 @@ ClientRouter.prototype.trackAction = function() {
 };
 
 ClientRouter.prototype.getView = function(key, entryPath, callback) {
-  var View = BaseView.getView(key, entryPath, function(View) {
+  var View = this.app.viewAdapter.getView(key, entryPath, function(View) {
     // TODO: Make it function (err, View)
     if (!_.isFunction(View)) {
       throw new Error("View '" + key + "' not found.");

--- a/examples/06_appview/app/views/app_view.js
+++ b/examples/06_appview/app/views/app_view.js
@@ -1,9 +1,15 @@
 var BaseAppView = require('rendr/client/app_view')
   , $ = require('jquery')
   , $body = $('body')
+  , _ = require('underscore');
 ;
 
-module.exports = BaseAppView.extend({
+module.exports = AppView;
+function AppView() {
+  BaseAppView.apply(this, arguments);
+}
+
+_.extend(AppView.prototype, BaseAppView.prototype, {
   postInitialize: function() {
     this.app.on('change:loading', function(app, loading) {
       $body.toggleClass('loading', loading);

--- a/shared/app.js
+++ b/shared/app.js
@@ -82,6 +82,13 @@ module.exports = Backbone.Model.extend({
     this.postInitialize();
   },
 
+  /**
+   * Proxy getView to viewAdapter
+   */
+  getView: function() {
+    return this.viewAdapter.getView.apply(this.viewAdapter,arguments)
+  },
+
   postInitialize: noop,
 
   /**

--- a/shared/app.js
+++ b/shared/app.js
@@ -6,6 +6,7 @@
 var Backbone = require('backbone'),
     Fetcher = require('./fetcher'),
     ModelUtils = require('./modelUtils'),
+    ViewAdapter = require('./viewAdapter'),
     isServer = (typeof window === 'undefined'),
     ClientRouter;
 
@@ -49,6 +50,11 @@ module.exports = Backbone.Model.extend({
      * templating system they want.
      */
     this.templateAdapter = require(this.get('templateAdapter'))({entryPath: entryPath});
+
+    /**
+     * Initialize the `viewAdapter`, which is used client and server.
+     */
+    this.viewAdapter = this.options.viewAdapter || new ViewAdapter();
 
     /**
      * Instantiate the `Fetcher`, which is used on client and server.

--- a/shared/viewAdapter.js
+++ b/shared/viewAdapter.js
@@ -1,0 +1,111 @@
+var requireAMD = require,
+  _ = require('underscore'),
+  async = require('async');
+
+/*
+ * A ViewAdapter implements two methods.
+ *
+ * The first is a `getView` method, which is used to turn a string name of a
+ * view into a constructor for a View.
+ *
+ * The second is an `attach` method, which is called in browser scope. `attach`
+ * finds all elements in the DOM that should be attached to View objects and
+ * construct them with the proper arguments.
+ *
+ */
+
+module.exports = ViewAdapter;
+function ViewAdapter() {}
+
+
+/* Public: turn a view's name into a view class
+ *
+ * viewName  - the name of the view to find
+ * entryPath - the entryPath of the rendr app
+ * callback  - an optional callback to pass the view class to instead of returning
+ *
+ * Returns a View class
+ */
+ViewAdapter.prototype.getView = function(viewName, entryPath, callback) {
+    var viewPath;
+
+    if (!entryPath) entryPath = '';
+
+    viewPath = entryPath + 'app/views/' + viewName;
+    // check for AMD environment
+    if (typeof callback == 'function') {
+      // Only used in AMD environment
+      if (typeof define != 'undefined') {
+        requireAMD([viewPath], callback);
+      } else {
+        callback(require(viewPath));
+      }
+    } else {
+      return require(viewPath);
+    }
+  };
+
+
+/* Private: extract rendr-generated options from an element's `data`
+ * attributes. JSON-encoded options are parsed and returned as sub objects.
+ *
+ * $el - the jquery object to extract options from
+ *
+ * Returns an object containing the options.
+ *
+ */
+ViewAdapter.prototype._optionsFromElement = function($el) {
+  var options = $el.data();
+  _.each(options, function(value, key) {
+    var parsed;
+    if (_.isString(value)) {
+      parsed = _.unescape(value);
+      try {
+        parsed = JSON.parse(parsed);
+      } catch (err) {}
+      options[key] = parsed;
+    }
+  });
+  return options;
+};
+
+/* Public: attach Views to all elements of the DOM that need it
+ *
+ * app        - the Rendr app
+ * parentView - the containing node to attach within
+ *
+ * Returns nothing, calls callback with an array of attached views
+ */
+ViewAdapter.prototype.attach = function(app, parentView, callback) {
+  var $scope = parentView ? parentView.$el : $('body'),
+      _this = this,
+      list;
+
+  // Find all elements with a data-view attribute in $scope that don't have a
+  // parent element with a data-view attribute in $scope
+  list = $scope.find('[data-view]').filter(function(i,el){
+    return $(el).parentsUntil($scope).filter('[data-view]').length === 0;
+  }).toArray();
+
+  async.map(list, function(el, cb) {
+    var $el, options, viewName;
+    $el = $(el);
+    if (!$el.data('view-attached')) {
+      options = _this._optionsFromElement($el);
+      options.app = app;
+
+      viewName = options.view;
+
+      _this.getView(viewName, app.options.entryPath, function(ViewClass) {
+        ViewClass.attachNewInstance($el, parentView, options, function(err,view) {
+          cb(err, view);
+        });
+      });
+    } else {
+      cb(null, null);
+    }
+  }, function(err, views) {
+    // no error handling originally
+    callback(_.compact(views));
+  });
+};

--- a/shared/viewAdapter.js
+++ b/shared/viewAdapter.js
@@ -54,8 +54,8 @@ ViewAdapter.prototype.getView = function(viewName, entryPath, callback) {
  * Returns an object containing the options.
  *
  */
-ViewAdapter.prototype._optionsFromElement = function($el) {
-  var options = $el.data();
+ViewAdapter.prototype._optionsFromElementData = function(elementData) {
+  var options = _.clone(elementData);
   _.each(options, function(value, key) {
     var parsed;
     if (_.isString(value)) {
@@ -91,7 +91,7 @@ ViewAdapter.prototype.attach = function(app, parentView, callback) {
     var $el, options, viewName;
     $el = $(el);
     if (!$el.data('view-attached')) {
-      options = _this._optionsFromElement($el);
+      options = _this._optionsFromElementData($el.data());
       options.app = app;
 
       viewName = options.view;

--- a/test/server/viewEngine.test.js
+++ b/test/server/viewEngine.test.js
@@ -1,14 +1,18 @@
 var should = require('chai').should(),
     sinon = require('sinon'),
     ViewEngine = require('../../server/viewEngine'),
-    BaseView = require('../../shared/base/view');
+    ViewAdapter = require('../../shared/viewAdapter');
 
+
+
+var viewAdapter = require('../../shared/viewAdapter')();
 describe('ViewEngine', function() {
-  var app, viewEngine;
+  var app, viewEngine, viewAdapter;
 
   beforeEach(function() {
 
     viewEngine = new ViewEngine;
+    viewAdapter = new ViewAdapter;
 
     function layoutTemplate(locals) {
       return '<body>'+locals.body+'</body>';
@@ -16,22 +20,23 @@ describe('ViewEngine', function() {
 
     function View () {
       return {
-        getHtml: sinon.stub().returns('contents')
+        getHtml: sinon.stub().callsArgWith(0,'contents')
       };
     }
 
-    sinon.stub(BaseView, 'getView').returns(View);
+    sinon.stub(viewAdapter, 'getView').returns(View);
     app = {
       templateAdapter: {
         getLayout: sinon.stub().yields(null, layoutTemplate)
       },
       toJSON: sinon.stub(),
+      viewAdapter: viewAdapter,
       options: {}
     };
   });
 
   afterEach(function() {
-    BaseView.getView.restore();
+    viewAdapter.getView.restore();
   });
 
   it("should lookup the layout template via the app's templateAdapter", function(done) {


### PR DESCRIPTION
This extracts some of base/view's functionality into a ViewAdapter, with a goal of making it feasible to use other View producing technologies with rendr. (React.js in my case.) There's an additional class method that all Rendr-view-making-things have to allow, "attachNewInstance", which is what is called from the top level attach to allow a different instantiation and attachment strategy.

BaseView's getHtml and ViewEngine's getViewHtml change to an async style to allow for view technologies that need it.

The viewAdapter is attached to the app instance, which has the side effect of cleaning up plugin code like in airbnb/rendr-handlebars#13 .

ViewAdapter.attach (previously BaseView.attach) has a functionality change. Instead of finding all [data-view] objects and trying to attach them, it finds the top level [data-view] elements inside the given scope.

The handlebars path does become dependent on airbnb/rendr-handlebars#13

--
Filter viewAdapter attach to only handle "top level" data-views, deferring attachment of nested to their own views/
Defer attachment strategy to view's class

Allow optional callback for BaseView getHtml. Use callback for server getViewHtml to allow different viewAdapters to be async.

Remove backbone view dependency on AppView. Add renderInside to view instances for view-tech agnostic rendering.