### PR TITLE
Remove URL data attributes in clientSync('create')

### DIFF
--- a/shared/syncer.js
+++ b/shared/syncer.js
@@ -32,8 +32,8 @@ var syncer = module.exports;
 function clientSync(method, model, options) {
   var data, error;
   data = _.clone(options.data);
-  options.url = this.getUrl(options.url, true, data);
   data = addApiParams(method, model, data);
+  options.url = this.getUrl(options.url, true, data);
   options.data = data;
   options.emulateJSON = true;
   error = options.error;


### PR DESCRIPTION
## Rough example

```
model = new RendrModel({parent_id:27, value:2})
model.url = "/parents/:parent_id"
model.save()
```

Should POST `{value:2}` to `/parents/27` but instead POSTs `{parent_id:27, value:2}`.
## Explanation

`getUrl` removes the keys from `data` that are referenced by the URL; however if `options.data` is `undefined` (e.g. on 'create') then there's no key to remove until `addApiParams` is called (which does `model.toJSON()`).

Calling `addApiParams` before `getUrl` solves this, but I'm not sure if it has any negative consequences.
