### PR TITLE
Fix memory store tests

### DIFF
--- a/test/shared/store/memory_store.test.js
+++ b/test/shared/store/memory_store.test.js
@@ -9,7 +9,7 @@ describe('MemoryStore', function() {
     store = new MemoryStore();
   });
 
-  it('should undefined for missing keys', function() {
+  it('should return undefined for missing keys', function() {
     var value = store.get('foobar');
     should.not.exist(value);
   });


### PR DESCRIPTION
It seems that the behavior of `memoryStore.get` has changed to be synchronous but the tests weren’t adapted. Because of that, no assertion was executed and the tests never failed.
