### PR TITLE
Fix test for 05_requirejs example

### DIFF
--- a/examples/05_requirejs/test/app/views/users_show_view.test.js
+++ b/examples/05_requirejs/test/app/views/users_show_view.test.js
@@ -1,11 +1,17 @@
 var should = require("should");
-var UsersShowView = require('../../../app/views/users/show');
+var UsersShowView = require('../../../app/views/users/show')
+  , App = require('../../../app/app')
+;
 
 describe('UsersShowView', function() {
 
+  beforeEach(function() {
+    this.app = new App({rootPath: '/'});
+  });
+
   it('should have repos data in getTemplateData', function() {
     var repos = [{foo: 'bar'}];
-    var view = new UsersShowView({ repos: repos });
+    var view = new UsersShowView({ repos: repos, app: this.app });
     var data = view.getTemplateData();
     data.should.have.property('repos', repos);
   });


### PR DESCRIPTION
In the timespan while the PR for `05_requirejs` was getting merged in, the branch diverged
and never picked up this change in test.

A check was added in `BaseView`'s construction to assert `options.app`
exists.
