### PR TITLE
Make sure renderOnRefresh works after hydration

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -25,9 +25,6 @@ module.exports = BaseView = Backbone.View.extend({
 
     this.name = this.name || this.app.modelUtils.underscorize(this.constructor.id || this.constructor.name);
     this.postInitialize();
-    if ((obj = this.model || this.collection) && this.renderOnRefresh) {
-      obj.on('refresh', this.render, this);
-    }
 
     this.render = this.render.bind(this);
   },
@@ -73,6 +70,10 @@ module.exports = BaseView = Backbone.View.extend({
 
     this.model = options.model;
     this.collection = options.collection;
+
+    if ((obj = this.model || this.collection) && this.renderOnRefresh) {
+      obj.on('refresh', this.render, this);
+    }
   },
 
   /**


### PR DESCRIPTION
When a view is hydrated with data from the server, ```initialize``` is run before ```this.[model|collection]``` is set, so the view wouldn't start listening on the object's ```refresh``` event.

Moving the event listener setup to ```parseOptions``` means the listener will be set up every time the view is passed new options.

This fix works for us but I'm not sure if it's the best place to put it. Would love some input on the placement before adding tests etc. Thanks!