### PR TITLE
Update examples to underscore@~1.5.2

### DIFF
--- a/examples/00_simple/package.json
+++ b/examples/00_simple/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "express": "~3",
-    "underscore": "~1.4.4",
+    "underscore": "~1.5.2",
     "rendr-handlebars": "0.2.0-rc1",
     "rendr": "0.5.0-rc1"
   },

--- a/examples/01_config/package.json
+++ b/examples/01_config/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "express": "~3",
-    "underscore": "~1.4.4",
+    "underscore": "~1.5.2",
     "async": "~0.1.22",
     "rendr-handlebars": "0.2.0-rc1",
     "rendr": "0.5.0-rc1",

--- a/examples/02_middleware/package.json
+++ b/examples/02_middleware/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "express": "~3",
-    "underscore": "~1.4.4",
+    "underscore": "~1.5.2",
     "async": "~0.1.22",
     "rendr-handlebars": "0.2.0-rc1",
     "rendr": "0.5.0-rc1",

--- a/examples/03_sessions/package.json
+++ b/examples/03_sessions/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "express": "~3",
-    "underscore": "~1.4.4",
+    "underscore": "~1.5.2",
     "async": "~0.1.22",
     "rendr-handlebars": "0.2.0-rc1",
     "rendr": "0.5.0-rc1",

--- a/examples/04_entrypath/package.json
+++ b/examples/04_entrypath/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "express": "~3",
-    "underscore": "~1.4.4",
+    "underscore": "~1.5.2",
     "async": "~0.1.22",
     "rendr-handlebars": "0.2.0-rc1",
     "rendr": "0.5.0-rc1",

--- a/examples/05_requirejs/package.json
+++ b/examples/05_requirejs/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "express": "~3",
-    "underscore": "~1.4.4",
+    "underscore": "~1.5.2",
     "async": "~0.2.9",
     "rendr-handlebars": "airbnb/rendr-handlebars",
     "rendr": "airbnb/rendr",

--- a/examples/06_appview/package.json
+++ b/examples/06_appview/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "express": "~3",
-    "underscore": "~1.4.4",
+    "underscore": "~1.5.2",
     "async": "~0.1.22",
     "rendr-handlebars": "0.2.0-rc1",
     "rendr": "0.5.0-rc1"


### PR DESCRIPTION
To match rendr's dependency on underscore@1.5.2.
