### PR TITLE
Extend constructor instead of initialize for base classes

### DIFF
--- a/client/app_view.js
+++ b/client/app_view.js
@@ -8,8 +8,8 @@ Backbone.$ = $;
 module.exports = BaseView.extend({
   el: 'body',
 
-  initialize: function() {
-    BaseView.prototype.initialize.apply(this, arguments);
+  constructor: function() {
+    BaseView.apply(this, arguments);
 
     _.defaults(this.options, {
       contentEl: '#content'

--- a/shared/base/collection.js
+++ b/shared/base/collection.js
@@ -18,7 +18,7 @@ BaseCollection = Super.extend({
    */
   defaultParams: null,
 
-  initialize: function(models, options) {
+  constructor: function(models, options) {
     /**
      * Capture the options as instance variable.
      */
@@ -45,6 +45,8 @@ BaseCollection = Super.extend({
       _.extend(this.meta, this.options.meta);
       delete this.options.meta;
     }
+
+    Super.apply(this, arguments);
   },
 
   /**

--- a/shared/base/model.js
+++ b/shared/base/model.js
@@ -9,16 +9,18 @@ if (!isServer) {
 
 var BaseModel = Backbone.Model.extend({
 
-  initialize: function(models, options) {
+  constructor: function(models, options) {
     // Capture the options as instance variable.
     this.options = options || {};
 
     // Store a reference to the app instance.
     this.app = this.options.app;
 
-    if (!this.app && this.collection) {
-      this.app = this.collection.app;
+    if (!this.app && this.options.collection) {
+      this.app = this.options.collection.app;
     }
+
+    Backbone.Model.apply(this, arguments);
 
     this.on('change', this.store, this);
   },

--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -18,14 +18,23 @@ if (!isServer) {
 function noop() {}
 
 module.exports = BaseView = Backbone.View.extend({
-  initialize: function(options) {
+  constructor: function(options) {
     var obj;
+
+    this.options = options || {};
 
     this.parseOptions(options);
 
     this.name = this.name || this.app.modelUtils.underscorize(this.constructor.id || this.constructor.name);
-    this.postInitialize();
-    if ((obj = this.model || this.collection) && this.renderOnRefresh) {
+
+    Backbone.View.apply(this, arguments);
+
+    if (this.postInitialize) {
+      console.warn('`postInitialize` is deprecated, please use `initialize`');
+      this.postInitialize();
+    }
+
+    if ((obj = this.options.model || this.options.collection) && this.renderOnRefresh) {
       obj.on('refresh', this.render, this);
     }
 
@@ -37,8 +46,6 @@ module.exports = BaseView = Backbone.View.extend({
    * emits a 'refresh' event. Used with 'model|collection.checkFresh()'.
    */
   renderOnRefresh: false,
-
-  postInitialize: noop,
 
   parseOptions: function(options) {
     /**

--- a/test/shared/app.test.js
+++ b/test/shared/app.test.js
@@ -1,0 +1,39 @@
+var sinon = require('sinon'),
+    should = require('chai').should(),
+    App = require('../../shared/app');
+
+describe('BaseApp', function() {
+  describe('initialize', function() {
+    it('is called', function() {
+      var MyApp = App.extend({
+        initialize: sinon.spy()
+      });
+
+      var app = new MyApp();
+
+      app.initialize.should.have.been.called;
+    });
+
+    it('calls `postInitialize` if present', function() {
+      var MyApp = App.extend({
+        postInitialize: sinon.spy()
+      });
+
+      var app = new MyApp();
+
+      app.postInitialize.should.have.been.called;
+    });
+
+    it('can access `this.templateAdapter` in `initialize`', function() {
+      var MyApp = App.extend({
+        initialize: function() {
+          if (this.templateAdapter == null) {
+            throw new Error('Cannot access `templateAdapter` in initialize');
+          }
+        }
+      });
+
+      new MyApp();
+    });
+  });
+});


### PR DESCRIPTION
See #281 and #294.

Override `constructor` of `BaseModel`, `BaseCollection`, `BaseView`,
`BaseApp` instead of `initialize`. Add a deprecation warning to
`postInitialize` in `BaseApp` and `BaseView`.

This should have zero behavioral changes.

@jeromegn @c089 @lo1tuma @alexindigo 
