### PR TITLE
Change Order of Grunt Tasks In Examples To Prevent Nodemon Restarts During Compile Task

### DIFF
--- a/examples/00_simple/Gruntfile.js
+++ b/examples/00_simple/Gruntfile.js
@@ -1,4 +1,3 @@
-
 var path = require('path');
 
 var stylesheetsDir = 'assets/stylesheets';
@@ -119,7 +118,7 @@ module.exports = function(grunt) {
   grunt.registerTask('compile', ['handlebars', 'browserify', 'stylus']);
 
   // Run the server and watch for file changes
-  grunt.registerTask('server', ['runNode', 'compile', 'watch']);
+  grunt.registerTask('server', ['compile', 'runNode', 'watch']);
 
   // Default task(s).
   grunt.registerTask('default', ['compile']);

--- a/examples/01_config/Gruntfile.js
+++ b/examples/01_config/Gruntfile.js
@@ -1,4 +1,3 @@
-
 var path = require('path');
 
 var stylesheetsDir = 'assets/stylesheets';
@@ -117,7 +116,7 @@ module.exports = function(grunt) {
   grunt.registerTask('compile', ['handlebars', 'browserify', 'stylus']);
 
   // Run the server and watch for file changes
-  grunt.registerTask('server', ['runNode', 'compile', 'watch']);
+  grunt.registerTask('server', ['compile', 'runNode', 'watch']);
 
   // Default task(s).
   grunt.registerTask('default', ['compile']);

--- a/examples/02_middleware/Gruntfile.js
+++ b/examples/02_middleware/Gruntfile.js
@@ -1,4 +1,3 @@
-
 var path = require('path');
 
 var stylesheetsDir = 'assets/stylesheets';
@@ -117,7 +116,7 @@ module.exports = function(grunt) {
   grunt.registerTask('compile', ['handlebars', 'browserify', 'stylus']);
 
   // Run the server and watch for file changes
-  grunt.registerTask('server', ['runNode', 'compile', 'watch']);
+  grunt.registerTask('server', ['compile', 'runNode', 'watch']);
 
   // Default task(s).
   grunt.registerTask('default', ['compile']);

--- a/examples/03_sessions/Gruntfile.js
+++ b/examples/03_sessions/Gruntfile.js
@@ -1,4 +1,3 @@
-
 var path = require('path');
 
 var stylesheetsDir = 'assets/stylesheets';
@@ -117,7 +116,7 @@ module.exports = function(grunt) {
   grunt.registerTask('compile', ['handlebars', 'browserify', 'stylus']);
 
   // Run the server and watch for file changes
-  grunt.registerTask('server', ['runNode', 'compile', 'watch']);
+  grunt.registerTask('server', ['compile', 'runNode', 'watch']);
 
   // Default task(s).
   grunt.registerTask('default', ['compile']);

--- a/examples/04_entrypath/Gruntfile.js
+++ b/examples/04_entrypath/Gruntfile.js
@@ -113,7 +113,7 @@ module.exports = function(grunt) {
   grunt.registerTask('compile', ['handlebars', 'browserify', 'stylus']);
 
   // Run the server and watch for file changes
-  grunt.registerTask('server', ['runNode', 'compile', 'watch']);
+  grunt.registerTask('server', ['compile', 'runNode', 'watch']);
 
   // Default task(s).
   grunt.registerTask('default', ['compile']);

--- a/examples/05_requirejs/Gruntfile.js
+++ b/examples/05_requirejs/Gruntfile.js
@@ -239,7 +239,7 @@ module.exports = function(grunt) {
   grunt.registerTask('compile', ['handlebars', 'stylus']);
 
   // Run the server and watch for file changes
-  grunt.registerTask('server', ['build_world', 'runNode', 'compile', 'watch']);
+  grunt.registerTask('server', ['build_world', 'compile', 'runNode', 'watch']);
 
   // Default task(s).
   grunt.registerTask('default', ['compile']);

--- a/examples/06_appview/Gruntfile.js
+++ b/examples/06_appview/Gruntfile.js
@@ -120,7 +120,7 @@ module.exports = function(grunt) {
   grunt.registerTask('compile', ['handlebars', 'browserify', 'stylus']);
 
   // Run the server and watch for file changes
-  grunt.registerTask('server', ['runNode', 'compile', 'watch']);
+  grunt.registerTask('server', ['compile', 'runNode', 'watch']);
 
   // Default task(s).
   grunt.registerTask('default', ['compile']);


### PR DESCRIPTION
Currently, the grunt server task in the example apps is registered as follows:

```
grunt.registerTask('server', ['runNode', 'compile', 'watch']);
```

This causes nodemon to restart the server as the compile task makes changes to files resulting in the following:

```
[petebuntu::~/workspace/06_appview]
pete-> grunt server
Running "runNode" task

Running "handlebars:compile" (handlebars) task
20 Feb 19:18:43 - [nodemon] v0.7.10
20 Feb 19:18:43 - [nodemon] to restart at any time, enter `rs`
20 Feb 19:18:43 - [nodemon] watching: /home/pete/workspace/06_appview
20 Feb 19:18:43 - [nodemon] starting `node index.js`
File "app/templates/compiledTemplates.js" created.

Running "browserify:app" (browserify) task
connect.multipart() will be removed in connect 3.0
visit https://github.com/senchalabs/connect/wiki/Connect-3.0 for alternatives
connect.limit() will be removed in connect 3.0
server pid 10431 listening on port 3030 in development mode
>> Bundled public/mergedAssets.js

Running "browserify:tests" (browserify) task
20 Feb 19:18:48 - [nodemon] restarting due to changes...
20 Feb 19:18:48 - [nodemon] /home/pete/workspace/06_appview/public/mergedAssets.js


20 Feb 19:18:48 - [nodemon] starting `node index.js`
connect.multipart() will be removed in connect 3.0
visit https://github.com/senchalabs/connect/wiki/Connect-3.0 for alternatives
connect.limit() will be removed in connect 3.0
server pid 10441 listening on port 3030 in development mode
>> Bundled public/testBundle.js

Running "stylus:compile" (stylus) task
File public/styles.css created.

Running "watch" task
Waiting...20 Feb 19:18:53 - [nodemon] restarting due to changes...
20 Feb 19:18:53 - [nodemon] /home/pete/workspace/06_appview/public/testBundle.js


20 Feb 19:18:53 - [nodemon] starting `node index.js`
connect.multipart() will be removed in connect 3.0
visit https://github.com/senchalabs/connect/wiki/Connect-3.0 for alternatives
connect.limit() will be removed in connect 3.0
server pid 10443 listening on port 3030 in development mode
```

Ordering the tasks as follows solves this problem:

```
grunt.registerTask('server', ['compile', 'runNode', 'watch']);
```
