### PR TITLE
Remove more links to the airbnb version of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <img src="http://cl.ly/image/272q3f1u313b/Rendr-logotype.png" width="395" height="100">
 
-Rendr is a small library from [Airbnb](https://www.airbnb.com) that allows you to run your [Backbone.js](http://backbonejs.org/) apps seamlessly on both the client and the server. Allow your web server to serve fully-formed HTML pages to any deep link of your app, while preserving the snappy feel of a traditional Backbone.js client-side MVC app.
+Rendr is a small library that allows you to run your [Backbone.js](http://backbonejs.org/) apps seamlessly on both the client and the server. Allow your web server to serve fully-formed HTML pages to any deep link of your app, while preserving the snappy feel of a traditional Backbone.js client-side MVC app.
 
 ## Reporting problems and getting help
 
@@ -331,16 +331,6 @@ Asset bundling and serving are outside of Rendr's scope. However, it does have s
 ## Notes
 
 Rendr uses the native ECMAScript 5 methods `Array.prototype.map`, `Function.prototype.bind`, `Object.create`, etc. If you plan to support older browsers, such as IE<=8, you should include the lovely [es5-shim](https://github.com/kriskowal/es5-shim) (and es5-sham) libraries as client-side dependencies.
-
-## TODO
-
-While we do have it powering a few apps in production here at Airbnb, Rendr is still a prototype. It's a [spike](http://scaledagileframework.com/spikes/); a functional proof-of-concept of a shared client-server architecture based on Backbone. Thus, it carries over a number of design quirks specific to its original use case, and it's not yet very generalized and modular.
-
-Some of the more glaring things to do:
-
-* Support Browserify and streamline module packaging.
-* Support templating solutions other than Handlebars.
-* Pull out routing code into separate module and share it between client and server, to prevent bugs arising from using `Backbone.history` to process routes in the client, and Express to process routes on the server.
 
 ## Contributing
 

--- a/examples/00_simple/README.md
+++ b/examples/00_simple/README.md
@@ -11,7 +11,7 @@ First, make sure to have Node >= 0.8.0 [installed on your system](http://nodejs.
 
     $ npm install -g grunt-cli
 
-If you see an error on startup that looks [like this](https://github.com/airbnb/rendr-app-template/issues/2), then you may need to un-install a global copy of `grunt`:
+If you see an error on startup that looks [like this](https://github.com/rendrjs/rendr-app-template/issues/2), then you may need to un-install a global copy of `grunt`:
 
     $ npm uninstall -g grunt
 
@@ -265,7 +265,7 @@ You probably shouldn't ever need to override this; by default it just combines t
 
 ## The view hierarchy
 
-Rendr provides a Handlebars helper `{{view}}` that allows you to declaratively nest your views, creating a view hierarchy that you can traverse in your JavaScript.  Check out [`app/templates/users/show.hbs`](https://github.com/airbnb/rendr-app-template/blob/master/app/templates/users/show.hbs) and [`app/views/users/show.js`](https://github.com/airbnb/rendr-app-template/blob/master/app/views/users/show.js) for an example:
+Rendr provides a Handlebars helper `{{view}}` that allows you to declaratively nest your views, creating a view hierarchy that you can traverse in your JavaScript.  Check out [`app/templates/users/show.hbs`](https://github.com/rendrjs/rendr-app-template/blob/master/app/templates/users/show.hbs) and [`app/views/users/show.js`](https://github.com/rendrjs/rendr-app-template/blob/master/app/views/users/show.js) for an example:
 
 ```html
 <!-- app/templates/users/show.hbs -->

--- a/examples/01_config/README.md
+++ b/examples/01_config/README.md
@@ -11,7 +11,7 @@ First, make sure to have Node >= 0.8.0 [installed on your system](http://nodejs.
 
     $ npm install -g grunt-cli
 
-If you see an error on startup that looks [like this](https://github.com/airbnb/rendr-app-template/issues/2), then you may need to un-install a global copy of `grunt`:
+If you see an error on startup that looks [like this](https://github.com/rendrjs/rendr-app-template/issues/2), then you may need to un-install a global copy of `grunt`:
 
     $ npm uninstall -g grunt
 
@@ -265,7 +265,7 @@ You probably shouldn't ever need to override this; by default it just combines t
 
 ## The view hierarchy
 
-Rendr provides a Handlebars helper `{{view}}` that allows you to declaratively nest your views, creating a view hierarchy that you can traverse in your JavaScript.  Check out [`app/templates/users/show.hbs`](https://github.com/airbnb/rendr-app-template/blob/master/app/templates/users/show.hbs) and [`app/views/users/show.js`](https://github.com/airbnb/rendr-app-template/blob/master/app/views/users/show.js) for an example:
+Rendr provides a Handlebars helper `{{view}}` that allows you to declaratively nest your views, creating a view hierarchy that you can traverse in your JavaScript.  Check out [`app/templates/users/show.hbs`](https://github.com/rendrjs/rendr-app-template/blob/master/app/templates/users/show.hbs) and [`app/views/users/show.js`](https://github.com/rendrjs/rendr-app-template/blob/master/app/views/users/show.js) for an example:
 
 ```html
 <!-- app/templates/users/show.hbs -->

--- a/examples/02_middleware/README.md
+++ b/examples/02_middleware/README.md
@@ -11,7 +11,7 @@ First, make sure to have Node >= 0.8.0 [installed on your system](http://nodejs.
 
     $ npm install -g grunt-cli
 
-If you see an error on startup that looks [like this](https://github.com/airbnb/rendr-app-template/issues/2), then you may need to un-install a global copy of `grunt`:
+If you see an error on startup that looks [like this](https://github.com/rendrjs/rendr-app-template/issues/2), then you may need to un-install a global copy of `grunt`:
 
     $ npm uninstall -g grunt
 
@@ -265,7 +265,7 @@ You probably shouldn't ever need to override this; by default it just combines t
 
 ## The view hierarchy
 
-Rendr provides a Handlebars helper `{{view}}` that allows you to declaratively nest your views, creating a view hierarchy that you can traverse in your JavaScript.  Check out [`app/templates/users/show.hbs`](https://github.com/airbnb/rendr-app-template/blob/master/app/templates/users/show.hbs) and [`app/views/users/show.js`](https://github.com/airbnb/rendr-app-template/blob/master/app/views/users/show.js) for an example:
+Rendr provides a Handlebars helper `{{view}}` that allows you to declaratively nest your views, creating a view hierarchy that you can traverse in your JavaScript.  Check out [`app/templates/users/show.hbs`](https://github.com/rendrjs/rendr-app-template/blob/master/app/templates/users/show.hbs) and [`app/views/users/show.js`](https://github.com/rendrjs/rendr-app-template/blob/master/app/views/users/show.js) for an example:
 
 ```html
 <!-- app/templates/users/show.hbs -->

--- a/examples/02_middleware/index.js
+++ b/examples/02_middleware/index.js
@@ -37,7 +37,7 @@ app.use(mw.addLocaleToRequest());
  * values that are not request-specific.
  */
 app.use(function(req, res, next) {
-  res.locals.repoUrl = 'https://github.com/airbnb/rendr';
+  res.locals.repoUrl = 'https://github.com/rendrjs/rendr';
   next();
 });
 

--- a/examples/03_sessions/README.md
+++ b/examples/03_sessions/README.md
@@ -11,7 +11,7 @@ First, make sure to have Node >= 0.8.0 [installed on your system](http://nodejs.
 
     $ npm install -g grunt-cli
 
-If you see an error on startup that looks [like this](https://github.com/airbnb/rendr-app-template/issues/2), then you may need to un-install a global copy of `grunt`:
+If you see an error on startup that looks [like this](https://github.com/rendrjs/rendr-app-template/issues/2), then you may need to un-install a global copy of `grunt`:
 
     $ npm uninstall -g grunt
 
@@ -265,7 +265,7 @@ You probably shouldn't ever need to override this; by default it just combines t
 
 ## The view hierarchy
 
-Rendr provides a Handlebars helper `{{view}}` that allows you to declaratively nest your views, creating a view hierarchy that you can traverse in your JavaScript.  Check out [`app/templates/users/show.hbs`](https://github.com/airbnb/rendr-app-template/blob/master/app/templates/users/show.hbs) and [`app/views/users/show.js`](https://github.com/airbnb/rendr-app-template/blob/master/app/views/users/show.js) for an example:
+Rendr provides a Handlebars helper `{{view}}` that allows you to declaratively nest your views, creating a view hierarchy that you can traverse in your JavaScript.  Check out [`app/templates/users/show.hbs`](https://github.com/rendrjs/rendr-app-template/blob/master/app/templates/users/show.hbs) and [`app/views/users/show.js`](https://github.com/rendrjs/rendr-app-template/blob/master/app/views/users/show.js) for an example:
 
 ```html
 <!-- app/templates/users/show.hbs -->

--- a/examples/04_entrypath/README.md
+++ b/examples/04_entrypath/README.md
@@ -11,7 +11,7 @@ First, make sure to have Node >= 0.8.0 [installed on your system](http://nodejs.
 
     $ npm install -g grunt-cli
 
-If you see an error on startup that looks [like this](https://github.com/airbnb/rendr-app-template/issues/2), then you may need to un-install a global copy of `grunt`:
+If you see an error on startup that looks [like this](https://github.com/rendrjs/rendr-app-template/issues/2), then you may need to un-install a global copy of `grunt`:
 
     $ npm uninstall -g grunt
 
@@ -265,7 +265,7 @@ You probably shouldn't ever need to override this; by default it just combines t
 
 ## The view hierarchy
 
-Rendr provides a Handlebars helper `{{view}}` that allows you to declaratively nest your views, creating a view hierarchy that you can traverse in your JavaScript.  Check out [`app/templates/users/show.hbs`](https://github.com/airbnb/rendr-app-template/blob/master/app/templates/users/show.hbs) and [`app/views/users/show.js`](https://github.com/airbnb/rendr-app-template/blob/master/app/views/users/show.js) for an example:
+Rendr provides a Handlebars helper `{{view}}` that allows you to declaratively nest your views, creating a view hierarchy that you can traverse in your JavaScript.  Check out [`app/templates/users/show.hbs`](https://github.com/rendrjs/rendr-app-template/blob/master/app/templates/users/show.hbs) and [`app/views/users/show.js`](https://github.com/rendrjs/rendr-app-template/blob/master/app/views/users/show.js) for an example:
 
 ```html
 <!-- app/templates/users/show.hbs -->

--- a/examples/05_requirejs/README.md
+++ b/examples/05_requirejs/README.md
@@ -11,7 +11,7 @@ First, make sure to have Node >= 0.8.0 [installed on your system](http://nodejs.
 
     $ npm install -g grunt-cli
 
-If you see an error on startup that looks [like this](https://github.com/airbnb/rendr-app-template/issues/2), then you may need to un-install a global copy of `grunt`:
+If you see an error on startup that looks [like this](https://github.com/rendrjs/rendr-app-template/issues/2), then you may need to un-install a global copy of `grunt`:
 
     $ npm uninstall -g grunt
 
@@ -295,7 +295,7 @@ You probably shouldn't ever need to override this; by default it just combines t
 
 ## The view hierarchy
 
-Rendr provides a Handlebars helper `{{view}}` that allows you to declaratively nest your views, creating a view hierarchy that you can traverse in your JavaScript.  Check out [`app/templates/users/show.hbs`](https://github.com/airbnb/rendr-app-template/blob/master/app/templates/users/show.hbs) and [`app/views/users/show.js`](https://github.com/airbnb/rendr-app-template/blob/master/app/views/users/show.js) for an example:
+Rendr provides a Handlebars helper `{{view}}` that allows you to declaratively nest your views, creating a view hierarchy that you can traverse in your JavaScript.  Check out [`app/templates/users/show.hbs`](https://github.com/rendrjs/rendr-app-template/blob/master/app/templates/users/show.hbs) and [`app/views/users/show.js`](https://github.com/rendrjs/rendr-app-template/blob/master/app/views/users/show.js) for an example:
 
 ```html
 <!-- app/templates/users/show.hbs -->

--- a/examples/06_appview/README.md
+++ b/examples/06_appview/README.md
@@ -11,7 +11,7 @@ First, make sure to have Node >= 0.8.0 [installed on your system](http://nodejs.
 
     $ npm install -g grunt-cli
 
-If you see an error on startup that looks [like this](https://github.com/airbnb/rendr-app-template/issues/2), then you may need to un-install a global copy of `grunt`:
+If you see an error on startup that looks [like this](https://github.com/rendrjs/rendr-app-template/issues/2), then you may need to un-install a global copy of `grunt`:
 
     $ npm uninstall -g grunt
 
@@ -265,7 +265,7 @@ You probably shouldn't ever need to override this; by default it just combines t
 
 ## The view hierarchy
 
-Rendr provides a Handlebars helper `{{view}}` that allows you to declaratively nest your views, creating a view hierarchy that you can traverse in your JavaScript.  Check out [`app/templates/users/show.hbs`](https://github.com/airbnb/rendr-app-template/blob/master/app/templates/users/show.hbs) and [`app/views/users/show.js`](https://github.com/airbnb/rendr-app-template/blob/master/app/views/users/show.js) for an example:
+Rendr provides a Handlebars helper `{{view}}` that allows you to declaratively nest your views, creating a view hierarchy that you can traverse in your JavaScript.  Check out [`app/templates/users/show.hbs`](https://github.com/rendrjs/rendr-app-template/blob/master/app/templates/users/show.hbs) and [`app/views/users/show.js`](https://github.com/rendrjs/rendr-app-template/blob/master/app/views/users/show.js) for an example:
 
 ```html
 <!-- app/templates/users/show.hbs -->

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/airbnb/rendr.git"
+    "url": "git://github.com/rendrjs/rendr.git"
   },
   "dependencies": {
     "underscore": "1.5.2",


### PR DESCRIPTION
Also remove text referring to Rendr as an Airbnb project.

Follow-up to https://github.com/rendrjs/rendr/pull/328
