### PR TITLE
Update `request` module from 2.30.0 to 2.34.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "qs": "0.6.6",
     "express": "~3",
     "sanitizer": "~0.1",
-    "request": "~2.30.0",
+    "request": "~2.34.0",
     "debug": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
David-dm was yelling at me because `request` module version was outdated.

The changelog doesn't seem to have anything that would break the RestAdapter:

https://github.com/mikeal/request/blob/master/CHANGELOG.md
