### PR TITLE
Support nested params in ServerRouter

### DIFF
--- a/server/router.js
+++ b/server/router.js
@@ -22,8 +22,12 @@ ServerRouter.prototype.constructor = ServerRouter;
 ServerRouter.prototype.escapeParams = function(params) {
   var escaped = {};
   _.each(params, function(value, key) {
-    escaped[sanitizer.sanitize(key)] = sanitizer.sanitize(value);
-  });
+    if (_.isObject(value)) {
+      escaped[sanitizer.sanitize(key)] = this.escapeParams(value);
+    } else {
+      escaped[sanitizer.sanitize(key)] = sanitizer.sanitize(value);
+    }
+  }, this);
   return escaped;
 };
 

--- a/test/server/router.test.js
+++ b/test/server/router.test.js
@@ -393,6 +393,24 @@ describe("server/router", function() {
           foo: 'sneaky'
         });
       });
+
+      it("recusively sanitizes nested objects", function() {
+        this.req.__defineGetter__('query', function() {
+          return {
+            nested: {
+              foo: '<script>alert("foo")</script>sneakyfoo',
+              bar: '<script>alert("bar")</script>sneakybar',
+            },
+          };
+        });
+
+        this.router.getParams(this.req).should.eql({
+          nested: {
+            foo: 'sneakyfoo',
+            bar: 'sneakybar',
+          },
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Recursively call `escapeParams()` on params so we can support nested params.
Otherwise, a querystring like:

```
nested[key1]=value1&nested[key2]=value2
```

becomes

```
{
 nested: '[Object object]'
}
```
