### PR TITLE
Ability to pass AppView options

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -56,7 +56,10 @@ ClientRouter.prototype.reverseRoutes = true;
 ClientRouter.prototype.initialize = function(options) {
   this.app = options.app;
 
-  var AppView = this.options.appViewClass;
+  var AppView = this.options.appViewClass,
+      options = _.defaults(options.viewOptions || {}, {
+        app: this.app
+      });
 
   // We do this here so that it's available in AppView initialization.
   this.app.router = this;
@@ -65,9 +68,7 @@ ClientRouter.prototype.initialize = function(options) {
   this.on('action:start', this.trackAction, this);
   this.app.on('reload', this.renderView, this);
 
-  this.appView = new AppView({
-    app: this.app
-  });
+  this.appView = new AppView(options);
 
   this.appView.render();
   this.buildRoutes();

--- a/shared/app.js
+++ b/shared/app.js
@@ -68,7 +68,8 @@ module.exports = Backbone.Model.extend({
         app: this,
         entryPath: entryPath,
         appViewClass: this.getAppViewClass(),
-        rootPath: attributes.rootPath
+        rootPath: attributes.rootPath,
+        viewOptions : options.viewOptions
       });
     }
 


### PR DESCRIPTION
In `0.4.x` there was the ability to set options in the `appView`. Mainly by overwriting the defaults. In `0.5.0` i seems the `appView` is omitted ( at least in the examples ). So instead of trying to overwrite those defaults I found a way that you can pass options to the `appView` when initializing the app. The main reason you would want to do this is to change the `contentEl` value.

``` javascript
var App = window.App = new (require('app/app'))({{json appData}}, {
    viewOptions : {  // this gets passed to the appView
        contentEl : '#main' 
    }
});
```

Clearly the intent was to have this overwritable because `_.defaults( this.options, {});` is already present in the 'rendr/client/app_view'.

Let me know if you would like to revise the way the `viewOptions` are passed.
