### PR TITLE
Call super constructor earlier in shared/app

### DIFF
--- a/shared/app.js
+++ b/shared/app.js
@@ -53,6 +53,8 @@ module.exports = Backbone.Model.extend({
     var templateAdapterModule = attributes.templateAdapter || this.defaults.templateAdapter;
     this.templateAdapter = require(templateAdapterModule)({entryPath: entryPath});
 
+    Backbone.Model.apply(this, arguments);
+
     /**
      * Instantiate the `Fetcher`, which is used on client and server.
      */
@@ -71,8 +73,6 @@ module.exports = Backbone.Model.extend({
         rootPath: attributes.rootPath
       });
     }
-
-    Backbone.Model.apply(this, arguments);
 
     if (this.postInitialize) {
       console.warn('`postInitialize` is deprecated, please use `initialize`');


### PR DESCRIPTION
`Fetcher` and `ClientRouter` are both passed `app: this` (which is expected to be a Backbone model) yet at that time `app` has not been fully initialized (for example, it has no `app.attributes` property) so operations you'd expect to succeed on a Backbone model (`this.app.get('something')`) throw errors.