### PR TITLE
Don’t let coveralls fail the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ node_js:
   - "0.8"
 notifications:
   email: false
-script:
-  - npm run-script coveralls
+after_success:
+  - npm run coveralls


### PR DESCRIPTION
If coveralls has server issues the travis build will fail. This change should prevent this.
