### PR TITLE
fixing client/server rendering inconsistencies for examples (issue #350)

### DIFF
--- a/examples/00_simple/app/controllers/users_controller.js
+++ b/examples/00_simple/app/controllers/users_controller.js
@@ -13,7 +13,7 @@ module.exports = {
 
   show: function(params, callback) {
     var spec = {
-      model: {model: 'User', params: params},
+      model: {model: 'User', params: params, ensureKeys: ['public_repos']},
       repos: {collection: 'Repos', params: {user: params.login}}
     };
     this.app.fetch(spec, function(err, result) {

--- a/examples/01_config/app/controllers/users_controller.js
+++ b/examples/01_config/app/controllers/users_controller.js
@@ -12,7 +12,7 @@ module.exports = {
 
   show: function(params, callback) {
     var spec = {
-      model: {model: 'User', params: params},
+      model: {model: 'User', params: params, ensureKeys: ['public_repos']},
       repos: {collection: 'Repos', params: {user: params.login}}
     };
     this.app.fetch(spec, function(err, result) {

--- a/examples/02_middleware/app/controllers/users_controller.js
+++ b/examples/02_middleware/app/controllers/users_controller.js
@@ -12,7 +12,7 @@ module.exports = {
 
   show: function(params, callback) {
     var spec = {
-      model: {model: 'User', params: params},
+      model: {model: 'User', params: params, ensureKeys: ['public_repos']},
       repos: {collection: 'Repos', params: {user: params.login}}
     };
     this.app.fetch(spec, function(err, result) {

--- a/examples/03_sessions/app/controllers/users_controller.js
+++ b/examples/03_sessions/app/controllers/users_controller.js
@@ -12,7 +12,7 @@ module.exports = {
 
   show: function(params, callback) {
     var spec = {
-      model: {model: 'User', params: params},
+      model: {model: 'User', params: params, ensureKeys: ['public_repos']},
       repos: {collection: 'Repos', params: {user: params.login}}
     };
     this.app.fetch(spec, function(err, result) {

--- a/examples/04_entrypath/apps/main/app/controllers/users_controller.js
+++ b/examples/04_entrypath/apps/main/app/controllers/users_controller.js
@@ -12,7 +12,7 @@ module.exports = {
 
   show: function(params, callback) {
     var spec = {
-      model: {model: 'User', params: params},
+      model: {model: 'User', params: params, ensureKeys: ['public_repos']},
       repos: {collection: 'Repos', params: {user: params.login}}
     };
     this.app.fetch(spec, function(err, result) {

--- a/examples/05_requirejs/app/controllers/users_controller.js
+++ b/examples/05_requirejs/app/controllers/users_controller.js
@@ -21,7 +21,7 @@ define(function(require) {
     show: function(params, callback) {
 
       var spec = {
-        model: {model: 'User', params: params},
+        model: {model: 'User', params: params, ensureKeys: ['public_repos']},
         repos: {collection: 'Repos', params: {user: params.login}}
       };
 

--- a/examples/06_appview/app/controllers/users_controller.js
+++ b/examples/06_appview/app/controllers/users_controller.js
@@ -14,7 +14,7 @@ module.exports = {
 
   show: function(params, callback) {
     var spec = {
-      model: {model: 'User', params: params},
+      model: {model: 'User', params: params, ensureKeys: ['public_repos']},
       repos: {collection: 'Repos', params: {user: params.login}}
     };
     this.app.fetch(spec, function(err, result) {


### PR DESCRIPTION
Just added ensureKeys: ['public_repos'] to the show section of the users_controller in all example files. 
