### PR TITLE
added a postHydrate event which is triggered once all of the data has be...

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -332,9 +332,11 @@ module.exports = BaseView = Backbone.View.extend({
         app: this.app
       }, function(err, results) {
         this.parseOptions(results);
+        this.trigger('postHydrate');
         callback(err);
       }.bind(this));
     } else {
+      this.trigger('postHydrate');
       callback(null);
     }
   },


### PR DESCRIPTION
...en fetched. This is important for attaching events to this.model or this.collection on initial page loads

Hey all, I found this to be extremely helpful for trying to listen to model / collection events.  There isn't a good place to bind to them because preRender is called for each render event, and initialize doesn't have the view hydrated yet. By adding a postHydrate trigger we can optionally include our own handler for this once we have all of the data for the view.

@lo1tuma do you think is okay? I was also thinking of adding a `noop` to the view to handle the `postHydrate` event.
