### PR TITLE
Router accepts a stream response from ViewEngine

### DIFF
--- a/server/router.js
+++ b/server/router.js
@@ -99,7 +99,7 @@ ServerRouter.prototype.getHandler = function(action, pattern, route) {
         if (err) return next(err);
         res.set(router.getHeadersForRoute(route));
 
-        if (html instanceof ReadableStream) {
+        if (ReadableStream && html instanceof ReadableStream) {
           html.pipe(res);
         } else {
           res.type('html').end(html);

--- a/test/server/router.test.js
+++ b/test/server/router.test.js
@@ -507,20 +507,21 @@ describe("server/router", function() {
         });
 
         describe('a streaming response', function(){
-          var stream;
+          it('should pipe the stream through the res object if streams2 available', function(){
 
-          beforeEach(function(){
-            stream = ReadableStream();
+            if (!ReadableStream) { return; }
+
+            var stream = ReadableStream();
             stream.pipe = sinon.stub();
-          });
 
-          it('should pipe the stream through the res object', function(){
             res.render.yields(null, stream);
             middleware(this.req, res);
 
             stream.pipe.should.have.been.calledOnce;
             stream.pipe.should.have.been.calledWithExactly(res);
-          })
+          });
+
+          
         });
 
         describe('a non-streaming response', function(){


### PR DESCRIPTION
Support streaming responses from the server by allowing a custom ViewEngine to return a stream rather than an html string.
