### PR TITLE
added the ability to create a new model for the view in the controller

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -188,12 +188,8 @@ module.exports = BaseView = Backbone.View.extend({
         if (_.isFunction(value.constructor) && value.constructor.id != null) {
           modelOrCollectionId = value.constructor.id;
           if (modelUtils.isModel(value)) {
-            id = value.get(value.idAttribute);
-            if (id == null) {
-              // Bail if there's no ID; someone's using `this.model` in a
-              // non-standard way, and that's okay.
-              return;
-            }
+            id = value.get(value.idAttribute) || '';
+
             // Cast the `id` attribute to string to ensure it's included in attributes.
             // On the server, it can be i.e. an `ObjectId` from Mongoose.
             value = id.toString();

--- a/shared/fetcher.js
+++ b/shared/fetcher.js
@@ -309,8 +309,14 @@ Fetcher.prototype.hydrate = function(summaries, options, callback) {
     if (summary.model != null) {
       results[name] = fetcher.modelStore.get(summary.model, summary.id, true);
 
-      if ((results[name] != null) && (options.app != null)) {
-        results[name].app = options.app;
+      if (options.app != null) {
+        if (results[name] != null) {
+          results[name].app = options.app;
+        } else {
+          if (summary.model && !summary.id) {
+            results[name] = options.app.modelUtils.getModel(summary.model, undefined, options)
+          }
+        }
       }
 
       cb(null);

--- a/test/shared/fetcher.test.js
+++ b/test/shared/fetcher.test.js
@@ -201,6 +201,28 @@ describe('fetcher', function() {
       });
     });
 
+    it('should be able to hydrate a new model', function () {
+      var fetchSummary, hydrated, listing, rawListing, results;
+
+      results = {
+        listing: new Listing(rawListing, {
+          app: this.app
+        })
+      };
+      fetchSummary = {
+        listing: {
+          model: 'listing'
+        }
+      };
+
+      fetcher.storeResults(results);
+      fetcher.hydrate(fetchSummary, function(err, hydrated) {
+        listing = hydrated.listing;
+        listing.should.be.an.instanceOf(Listing);
+        listing.toJSON().should.eql({});
+      });
+    });
+
     it("should be able to store and hydrate a collection", function() {
       var fetchSummary, hydrated, listings, params, rawListings, results;
 


### PR DESCRIPTION
I added the ability to have the controller take care of new models in it - rather than having to create them in the initialize and another place that relies on `this.parentView.model` stuff.  This gives the ability to make a more dynamic page by having an empty model that we can setup listeners on at initialize and provide a richer page.

Usage:

``` javascript
// in some controller, be able to setup a CRUD UI
create: function(params, callback) {
  var spec = {
    model: { model: 'User' }
    ... additional fetch requests...
  };

  this.app.fetch(spec, callback);
}

// or if we don't have any other things in a spec it can be short handed to this
create: function(params, callback) {
  callback(null, { 
    model: this.app.modelUtils.getModel('User', undefined, { app: this.app })
  });
}
```

tl;dr - Issue #96 allows us to do CRUD for a collection - but nothing to do it for a new model... this should fix that.
