### PR TITLE
Make the rest adapter respect port configuration

### DIFF
--- a/server/data_adapter/rest_adapter.js
+++ b/server/data_adapter/rest_adapter.js
@@ -122,6 +122,10 @@ RestAdapter.prototype.apiDefaults = function(api, req) {
   );
   urlOpts.pathname = api.path || api.pathname;
 
+  // By host we mean hostname: http://nodejs.org/api/url.html#url_url_format_urlobj
+  urlOpts.hostname = urlOpts.host;
+  delete urlOpts.host;
+
   _.defaults(api, {
     method: 'GET',
     url: url.format(urlOpts),


### PR DESCRIPTION
Fix #307 by changing 'host' to 'hostname' dynamically, thus making url.format include port.
