### PR TITLE
Support `hostname` property in RestAdapter

### DIFF
--- a/server/data_adapter/rest_adapter.js
+++ b/server/data_adapter/rest_adapter.js
@@ -118,7 +118,7 @@ RestAdapter.prototype.apiDefaults = function(api, req) {
 
   urlOpts = _.defaults(
     _.pick(api,     ['protocol', 'port', 'query']),
-    _.pick(apiHost, ['protocol', 'port', 'host'])
+    _.pick(apiHost, ['protocol', 'port', 'host', 'hostname'])
   );
   urlOpts.pathname = api.path || api.pathname;
 

--- a/test/server/data_adapter/rest_adapter.test.js
+++ b/test/server/data_adapter/rest_adapter.test.js
@@ -128,6 +128,43 @@ describe('RestAdapter', function() {
       restAdapter.apiDefaults({body: {}}).should.have.property('url', 'https://example.com');
     });
 
+    it('should handle hostname and port', function () {
+      restAdapter.options.default = {
+        protocol: 'https',
+        hostname: 'google.org',
+        port: 1337,
+      };
+
+      var api = {
+        path: '/v1/dogs',
+        query: {
+          size: 'small'
+        },
+        body: {}
+      };
+
+      restAdapter.apiDefaults(api).should.have.property('url',
+        'https://google.org:1337/v1/dogs?size=small');
+    });
+
+    it('should handle host and port', function () {
+      restAdapter.options.default = {
+        protocol: 'https',
+        host: 'google.org:1337',
+      };
+
+      var api = {
+        path: '/v1/dogs',
+        query: {
+          size: 'small'
+        },
+        body: {}
+      };
+
+      restAdapter.apiDefaults(api).should.have.property('url',
+        'https://google.org:1337/v1/dogs?size=small');
+    });
+
     it('should use the configured api', function () {
       var api = {
           api: 'myCustomApi',
@@ -150,11 +187,11 @@ describe('RestAdapter', function() {
           api: 'myCustomApi',
           body: {}
         },
-        expectedUrl = 'https://myCustomHost?foo=bar',
+        expectedUrl = 'https://myCustomHost:3001?foo=bar',
         result;
 
       restAdapter.options.myCustomApi = {
-        host: 'myCustomHost',
+        hostname: 'myCustomHost',
         protocol: 'http',
         port: 3000
       };


### PR DESCRIPTION
Previously, when constructing a URL based on an object,
`RestAdapter` supported the `host` property but not the `hostname`
property. A side effect of this was that `host` overrode the `port`
property, because according to the `url` docs, `host` is supposed to be
a string that contains the `port`:

http://nodejs.org/api/url.html#url_url_format_urlobj

This change allows specifying `hostname` instead of `host`, which in
turn allows specifying `port` as a separate property.

This is a slightly more flexible take on https://github.com/rendrjs/rendr/pull/373.
