### PR TITLE
Make rendr app mountable under Express 4

### DIFF
--- a/server/router.js
+++ b/server/router.js
@@ -32,6 +32,12 @@ ServerRouter.prototype.escapeParams = function(params) {
 };
 
 ServerRouter.prototype.getParams = function(req) {
+  if (!_.isArray(req.params)) {
+    // Express 4
+    return this.escapeParams(_.extend({}, req.query, req.params));
+  }
+
+  // Express 3
   var params = _.clone(req.query || {});
 
   if (req.route.regexp) {

--- a/test/server/router.test.js
+++ b/test/server/router.test.js
@@ -302,75 +302,129 @@ describe("server/router", function() {
 
       resetProperties(this.req, {
         query: {},
+        params: null,
         route: {keys: [], params: {}, regexp: false},
       });
       this.router.getParams(this.req).should.eql({});
     });
 
-    it("should return basic query params", function() {
-      this.req.__defineGetter__('query', function() {
-        return {foo: 'bar', bam: 'baz'};
+    context("running under Express 4", function () {
+      it("should return basic query params", function() {
+        this.req.__defineGetter__('query', function() {
+          return {foo: 'bar', bam: 'baz'};
+        });
+        this.router.getParams(this.req).should.eql({foo: 'bar', bam: 'baz'});
       });
-      this.router.getParams(this.req).should.eql({foo: 'bar', bam: 'baz'});
+
+      it("should support route params", function() {
+        this.req.__defineGetter__('route', function() {
+          return {
+            keys: [{name: 'id'}, {name: 'login'}],
+          };
+        });
+        this.req.__defineGetter__('params', function() {
+          return {
+            'id': 'id-value',
+            'login': 'login-value'
+          };
+        });
+        this.router.getParams(this.req).should.eql({
+          id: 'id-value',
+          login: 'login-value'
+        });
+      });
+
+      it("should support both together", function() {
+        this.req.__defineGetter__('query', function() {
+          return {foo: 'bar', bam: 'baz'};
+        });
+
+        this.req.__defineGetter__('route', function() {
+          return {
+            keys: [{name: 'id'}, {name: 'login'}],
+          };
+        });
+        this.req.__defineGetter__('params', function() {
+          return {
+            'id': 'id-value',
+            'login': 'login-value'
+          };
+        });
+
+        this.router.getParams(this.req).should.eql({
+          foo: 'bar',
+          bam: 'baz',
+          id: 'id-value',
+          login: 'login-value'
+        });
+      });
     });
 
-    it("should support regex route params", function() {
-      this.req.__defineGetter__('route', function() {
-        return {
-          regexp: true
-        };
+    context("running under Express 3", function () {
+      it("should return basic query params", function() {
+        this.req.__defineGetter__('query', function() {
+          return {foo: 'bar', bam: 'baz'};
+        });
+        this.router.getParams(this.req).should.eql({foo: 'bar', bam: 'baz'});
       });
-      this.req.__defineGetter__('params', function() {
-        return {
+
+      it("should support regex route params", function() {
+        this.req.__defineGetter__('route', function() {
+          return {
+            regexp: true
+          };
+        });
+        this.req.__defineGetter__('params', function() {
+          return ['zero-value'];
+        });
+        this.router.getParams(this.req).should.eql({
           '0': 'zero-value'
-        };
+        });
       });
-      this.router.getParams(this.req).should.eql({
-        '0': 'zero-value'
-      });
-    });
 
-    it("should support route params", function() {
-      this.req.__defineGetter__('route', function() {
-        return {
-          keys: [{name: 'id'}, {name: 'login'}],
-        };
-      });
-      this.req.__defineGetter__('params', function() {
-        return {
+      it("should support route params", function() {
+        this.req.__defineGetter__('route', function() {
+          return {
+            keys: [{name: 'id'}, {name: 'login'}],
+          };
+        });
+        this.req.__defineGetter__('params', function() {
+          var ret = [];
+          ret.id = 'id-value';
+          ret.login = 'login-value';
+          return ret;
+        });
+        this.router.getParams(this.req).should.eql({
           id: 'id-value',
           login: 'login-value'
-        }
-      });
-      this.router.getParams(this.req).should.eql({
-        id: 'id-value',
-        login: 'login-value'
-      });
-    });
-
-    it("should support both together", function() {
-      this.req.__defineGetter__('query', function() {
-        return {foo: 'bar', bam: 'baz'};
+        });
       });
 
-      this.req.__defineGetter__('route', function() {
-        return {
-          keys: [{name: 'id'}, {name: 'login'}],
-        };
-      });
-      this.req.__defineGetter__('params', function() {
-        return {
+      it("should support both together", function() {
+        this.req.__defineGetter__('query', function() {
+          return {foo: 'bar', bam: 'baz'};
+        });
+
+        this.req.__defineGetter__('route', function() {
+          return {
+            keys: [{name: 'id'}, {name: 'login'}],
+          };
+        });
+        this.req.__defineGetter__('params', function() {
+          var ret = [];
+          ret.id = 'id-value';
+          ret.login = 'login-value';
+          return ret;
+        });
+
+        this.router.getParams(this.req).should.eql({
+          foo: 'bar',
+          bam: 'baz',
           id: 'id-value',
           login: 'login-value'
-        }
+        });
       });
 
-      this.router.getParams(this.req).should.eql({
-        foo: 'bar',
-        bam: 'baz',
-        id: 'id-value',
-        login: 'login-value'
-      });
     });
 
     describe('XSS sanitization', function() {


### PR DESCRIPTION
This simply makes it possible to mount a Rendr app inside an Express 4 app. The main issue was dealing with the newly-formatted `req.params` which are created by the hosting Express app at the newer version.

To mount a Rendr app in Express 4 you also need to supply an `errorHandler` in the options to `createServer` (otherwise Rendr falls back on `express.errorHandler()` which no longer exists), and `app.use(server.handle)` instead of `app.use(server)`.
