### PR TITLE
Changed the getBootstrappedData function to add each model of a collection to the modelStore

### DIFF
--- a/server/viewEngine.js
+++ b/server/viewEngine.js
@@ -85,7 +85,7 @@ ViewEngine.prototype.getBootstrappedData = function getBootstrappedData(locals, 
       _.each(list, function (value, key) {
         if (app.modelUtils.isModel(value) || app.modelUtils.isCollection(value)) {
           var tempObject = {},
-              key = (key !== value.cid && isNaN(parseInt(key))) ? key : value.cid;
+              key = app.modelUtils.modelName(value.constructor) + ':' + value.id
 
           tempObject[key] = value;
           _.defaults(bootstrappedData, scope.getBootstrappedData(tempObject, app));

--- a/test/server/viewEngine.test.js
+++ b/test/server/viewEngine.test.js
@@ -82,7 +82,7 @@ describe('ViewEngine', function() {
 
     it('should create bootstrap data from models and collection', function () {
       var locals = {
-          foo: new  Model({ id: 321, foo: 'bar' }, { app: app }),
+          foo: new Model({ id: 321, foo: 'bar' }, { app: app }),
           bar: new Collection([ new Model({ id: 123, foo: 'bar' }, { app: app} ) ], { app: app })
         },
         expectedData = {
@@ -97,7 +97,7 @@ describe('ViewEngine', function() {
         },
         data;
 
-      expectedData[locals.bar.models[0].cid] = {
+      expectedData['model:' + locals.bar.models[0].id] = {
         data: { foo: 'bar', id: 123 },
         summary: { model: 'model', id: 123 }
       }
@@ -123,7 +123,7 @@ describe('ViewEngine', function() {
                 data: { bar: bar, id: 321 },
                 summary: { model: 'model', id: 321 }
               },
-              bar: {
+              'model:123': {
                 data: { id: 123 },
                 summary: { model: 'model', id: 123 }
               }
@@ -135,32 +135,33 @@ describe('ViewEngine', function() {
     });
 
     it('should create a flat bootstrap object if a model has a nested collection', function () {
-        var foo = new  Model({ id: 321, foo: 'foo' }, { app: app }),
+        var foo = new Model({ id: 321, foo: 'foo' }, { app: app }),
             baz = new Collection([foo], { app: app }),
-            bar = new  Model({ id: 123, foo: 'bar', items: baz }, { app: app }),
+            bar = new Model({ id: 123, foo: 'bar', items: baz }, { app: app }),
             locals = {
-              foo: foo,
               bar: bar
             },
             expectedData = {
-                foo: {
-                  data: { foo: 'foo', id: 321 },
-                  summary: { model: 'model', id: 321 }
-                },
                 bar: {
-                  data: { foo: 'bar', id: 123, items: baz },
-                  summary: { model: 'model', id: 123 }
+                    data: { foo: 'bar', id: 123, items: baz },
+                    summary: { model: 'model', id: 123 }
                 },
-                items: {
-                  data: [ { foo: 'foo', id: 321 } ],
-                  summary: { collection: 'collection', ids: [ 321 ], meta: {}, params: {} }
+                'model:321': {
+                    data: { foo: 'foo', id: 321 },
+                    summary: { model: 'model', id: 321 }
                 }
             },
             data;
 
-        expectedData[baz.models[0].cid] = {
-          data: { foo: 'foo', id: 321 },
-          summary: { model: 'model', id: 321 }
+        baz.id = 111;
+        expectedData['collection:' + baz.id] = {
+            data: [{ foo: 'foo', id: 321 }],
+            summary: {
+                collection: 'collection',
+                ids: [321],
+                meta: {},
+                params: {}
+            }
         };
 
         data = viewEngine.getBootstrappedData(locals, app);


### PR DESCRIPTION
Added each model that's part of a collection to the bootstrappedData - this way we can access them singularly without having to request the single model inside of the collection.

This also fixes an issue if there were two models with a sub-model of the same key.
