### PR TITLE
Sanitize bootstrap data

### DIFF
--- a/server/viewEngine.js
+++ b/server/viewEngine.js
@@ -69,18 +69,23 @@ ViewEngine.prototype.getViewHtml = function getViewHtml(viewPath, locals, app) {
   return view.getHtml();
 };
 
-ViewEngine.prototype.getBootstrappedData = function getBootstrappedData(locals, app) {
+ViewEngine.prototype._getBootstrappedData = function _getBootstrappedData(locals, app) {
   var bootstrappedData = {};
 
   _.each(locals, function(modelOrCollection, name) {
     if (app.modelUtils.isModel(modelOrCollection) || app.modelUtils.isCollection(modelOrCollection)) {
       bootstrappedData[name] = {
         summary: app.fetcher.summarize(modelOrCollection),
-        data: app.modelUtils.deepEscape(modelOrCollection.toJSON())
+        data: modelOrCollection.toJSON()
       };
     }
   });
   return bootstrappedData;
+};
+
+ViewEngine.prototype.getBootstrappedData = function getBootstrappedData(locals, app) {
+  var data = this._getBootstrappedData(locals, app);
+  return app.modelUtils.deepEscape(data);
 };
 
 ViewEngine.prototype.clearCachedLayouts = function () {

--- a/server/viewEngine.js
+++ b/server/viewEngine.js
@@ -76,7 +76,7 @@ ViewEngine.prototype.getBootstrappedData = function getBootstrappedData(locals, 
     if (app.modelUtils.isModel(modelOrCollection) || app.modelUtils.isCollection(modelOrCollection)) {
       bootstrappedData[name] = {
         summary: app.fetcher.summarize(modelOrCollection),
-        data: modelOrCollection.toJSON()
+        data: app.modelUtils.deepEscape(modelOrCollection.toJSON())
       };
     }
   });

--- a/shared/fetcher.js
+++ b/shared/fetcher.js
@@ -276,7 +276,7 @@ Fetcher.prototype.bootstrapData = function(modelMap) {
       fetcher = this;
 
   async.forEach(_.keys(modelMap), function(name, cb) {
-    var map = modelMap[name];
+    var map = fetcher.app.modelUtils.deepUnescape(modelMap[name]);
     fetcher.getModelOrCollectionForSpec(map.summary, map.data, _.pick(map.summary, 'params', 'meta'), function(modelOrCollection) {
       results[name] = modelOrCollection;
       cb(null);

--- a/shared/modelUtils.js
+++ b/shared/modelUtils.js
@@ -5,6 +5,8 @@
  */
 var BaseModel = require("./base/model"),
     BaseCollection = require("./base/collection");
+    sanitizer = require("sanitizer");
+    _ = require("underscore");
 
 var typePath = {
   model: "app/models/",
@@ -135,4 +137,33 @@ ModelUtils.prototype.modelIdAttribute = function(modelName, callback) {
   this.getModelConstructor(modelName, function(constructor) {
     callback(constructor.prototype.idAttribute);
   });
+};
+
+ModelUtils.prototype.deepEscape = function(modelOrCollection) {
+  _.each(modelOrCollection, function(value, key) {
+    if(_.isString(value)) {
+      modelOrCollection[key] = sanitizer.escape(value);
+    } else if (_.isObject(value)) {
+      _.each(modelOrCollection[key], function(innerValue, innerKey) {
+        if(_.isString(innerValue)) {
+          modelOrCollection[key][innerKey] = sanitizer.escape(innerValue);
+        }
+      });
+    }
+  });
+  return modelOrCollection;
+};
+ModelUtils.prototype.deepUnescape = function(modelOrCollection) {
+  _.each(modelOrCollection, function(value, key) {
+    if(_.isString(value)) {
+      modelOrCollection[key] = sanitizer.unescapeEntities(value);
+    } else if (_.isObject(value)) {
+      _.each(modelOrCollection[key], function(innerValue, innerKey) {
+        if(_.isString(innerValue)) {
+          modelOrCollection[key][innerKey] = sanitizer.unescapeEntities(innerValue);
+        }
+      });
+    }
+  });
+  return modelOrCollection;
 };

--- a/test/server/viewEngine.test.js
+++ b/test/server/viewEngine.test.js
@@ -121,6 +121,27 @@ describe('ViewEngine', function() {
       data.should.deep.equal(expectedData);
     });
 
+    it('should escape bootstrapped data from nested models', function() {
+      var bar = new Model({id: 322, foo: '<blah>'});
+      var locals = {
+        foo: new Model({ id: 321, foo: '<bar>', bar: bar }, { app: app })
+        },
+        expectedData = {
+          bar: {
+            data: { foo: '&lt;blah&gt;', id: 322 },
+            summary: { model: 'model', id: 322 }
+          },
+          foo: {
+            data: { foo: '&lt;bar&gt;', id: 321, bar: bar },
+            summary: { model: 'model', id: 321 }
+          },
+        },
+        data;
+
+      data = viewEngine.getBootstrappedData(locals, app);
+      data.should.deep.equal(expectedData);
+    });
+
     it('should ignore properties which aren’t a model or collection', function () {
       var locals = { foo: true, bar: [ 1, 2, 3, 4 ] },
         data = viewEngine.getBootstrappedData(locals, app);

--- a/test/server/viewEngine.test.js
+++ b/test/server/viewEngine.test.js
@@ -121,27 +121,6 @@ describe('ViewEngine', function() {
       data.should.deep.equal(expectedData);
     });
 
-    it('should escape bootstrapped data from nested models', function() {
-      var bar = new Model({id: 322, foo: '<blah>'});
-      var locals = {
-        foo: new Model({ id: 321, foo: '<bar>', bar: bar }, { app: app })
-        },
-        expectedData = {
-          bar: {
-            data: { foo: '&lt;blah&gt;', id: 322 },
-            summary: { model: 'model', id: 322 }
-          },
-          foo: {
-            data: { foo: '&lt;bar&gt;', id: 321, bar: bar },
-            summary: { model: 'model', id: 321 }
-          },
-        },
-        data;
-
-      data = viewEngine.getBootstrappedData(locals, app);
-      data.should.deep.equal(expectedData);
-    });
-
     it('should ignore properties which aren’t a model or collection', function () {
       var locals = { foo: true, bar: [ 1, 2, 3, 4 ] },
         data = viewEngine.getBootstrappedData(locals, app);

--- a/test/server/viewEngine.test.js
+++ b/test/server/viewEngine.test.js
@@ -100,6 +100,27 @@ describe('ViewEngine', function() {
       data.should.deep.equal(expectedData);
     });
 
+    it('should escape bootstrapped data from models and collection', function() {
+      var locals = {
+          foo: new  Model({ id: 321, foo: '<bar>' }, { app: app }),
+          bar: new Collection([ new Model({ id: 123, foo: '<bar>' }, { app: app} ) ], { app: app })
+        },
+        expectedData = {
+          foo: {
+            data: { foo: '&lt;bar&gt;', id: 321 },
+            summary: { model: 'model', id: 321 }
+          },
+          bar: {
+            data: [ { foo: '&lt;bar&gt;', id: 123 } ],
+            summary: { collection: 'collection', ids: [ 123 ], meta: {}, params: {} }
+          }
+        },
+        data;
+
+      data = viewEngine.getBootstrappedData(locals, app);
+      data.should.deep.equal(expectedData);
+    });
+
     it('should ignore properties which aren’t a model or collection', function () {
       var locals = { foo: true, bar: [ 1, 2, 3, 4 ] },
         data = viewEngine.getBootstrappedData(locals, app);

--- a/test/shared/modelUtils.test.js
+++ b/test/shared/modelUtils.test.js
@@ -328,11 +328,28 @@ describe('modelUtils', function () {
       modelUtils.deepEscape(data).should.deep.equal(expectedData);
     });
     it('should escape attributes of a collection JSON', function() {
-      var data = [{foo: '<bar>', id: 321},{foo: '<blah>', id: 322}]
+      var data = [{foo: '<bar>', id: 321},{foo: '<blah>', id: 322}],
           expectedData = [{foo: '&lt;bar&gt;', id: 321 }, {foo: '&lt;blah&gt;', id: 322}];
 
       modelUtils.deepEscape(data).should.deep.equal(expectedData);
     });
+
+    it('should not recurse infinitely while escaping', function() {
+      var foo = {};
+      var bar = {bar: '<blah>'};
+      foo.bar = bar;
+      bar.foo = foo;
+
+      var data = foo,
+        expectedData = {
+          bar: {
+            bar: '&lt;blah&gt;',
+            foo: foo
+          }
+        };
+      modelUtils.deepEscape(data).should.deep.equal(expectedData);
+    });
+
   });
   describe('deepUnescape', function () {
     it('should unescape attributes of a model JSON', function() {
@@ -342,9 +359,25 @@ describe('modelUtils', function () {
       modelUtils.deepUnescape(data).should.deep.equal(expectedData);
     });
     it('should unescape attributes of a collection JSON', function() {
-      var expectedData = [{foo: '<bar>', id: 321},{foo: '<blah>', id: 322}]
+      var expectedData = [{foo: '<bar>', id: 321},{foo: '<blah>', id: 322}],
           data = [{foo: '&lt;bar&gt;', id: 321 }, {foo: '&lt;blah&gt;', id: 322}];
 
+      modelUtils.deepUnescape(data).should.deep.equal(expectedData);
+    });
+
+    it('should not recurse infinitely while unescaping', function() {
+      var foo = {};
+      var bar = {bar: '&lt;blah&gt;'};
+      foo.bar = bar;
+      bar.foo = foo;
+
+      var data = foo,
+        expectedData = {
+          bar: {
+            bar: '<blah>',
+            foo: foo
+          }
+        };
       modelUtils.deepUnescape(data).should.deep.equal(expectedData);
     });
   });

--- a/test/shared/modelUtils.test.js
+++ b/test/shared/modelUtils.test.js
@@ -320,4 +320,32 @@ describe('modelUtils', function () {
       });
     });
   });
+  describe('deepEscape', function () {
+    it('should escape attributes of a model JSON', function() {
+      var data = {foo: '<bar>', id: 321},
+          expectedData = {foo: '&lt;bar&gt;', id: 321 };
+
+      modelUtils.deepEscape(data).should.deep.equal(expectedData);
+    });
+    it('should escape attributes of a collection JSON', function() {
+      var data = [{foo: '<bar>', id: 321},{foo: '<blah>', id: 322}]
+          expectedData = [{foo: '&lt;bar&gt;', id: 321 }, {foo: '&lt;blah&gt;', id: 322}];
+
+      modelUtils.deepEscape(data).should.deep.equal(expectedData);
+    });
+  });
+  describe('deepUnescape', function () {
+    it('should unescape attributes of a model JSON', function() {
+      var expectedData = {foo: '<bar>', id: 321},
+          data = {foo: '&lt;bar&gt;', id: 321 };
+
+      modelUtils.deepUnescape(data).should.deep.equal(expectedData);
+    });
+    it('should unescape attributes of a collection JSON', function() {
+      var expectedData = [{foo: '<bar>', id: 321},{foo: '<blah>', id: 322}]
+          data = [{foo: '&lt;bar&gt;', id: 321 }, {foo: '&lt;blah&gt;', id: 322}];
+
+      modelUtils.deepUnescape(data).should.deep.equal(expectedData);
+    });
+  });
 });


### PR DESCRIPTION
## The issue:

If there are any model fields that contain unsafe user data, even if they all handled safely within views the bootstrap process does not escape them properly, resulting in all sorts of XSS vulnerabilities etc.

## Example:

User data that sets .e.g. name to ```</script><script>alert('hi!') // and do something nasty</script>``` will get written inline within the bootstrap and the script will execute.

## The solution:

escape strings in the data returned by ViewEngine.prototype.getBootstrappedData and unescape it again on the other side in Fetcher.prototype.bootstrapData