### PR TITLE
pass the app to getModel when constructing a model from the options passed to a view

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -471,8 +471,6 @@ BaseView.attach = function(app, parentView, callback) {
 BaseView.parseModelAndCollection = function(modelUtils, options) {
   if (options.model != null) {
     if (!(options.model instanceof Backbone.Model) && options.model_name) {
-      if (!options.app) throw new Error("options.app required for creating a Model")
-
       options.model = modelUtils.getModel(options.model_name, options.model, {
         parse: true,
         app: options.app

--- a/test/shared/base/view.test.js
+++ b/test/shared/base/view.test.js
@@ -280,10 +280,6 @@ describe('BaseView', function() {
             app: this.app
           });
         });
-
-        it('it should throw if not passed app as an option', function () {
-          BaseView.parseModelAndCollection.bind(modelUtils, { model: modelData, model_name: 'MyModel' }).should.Throw;
-        });
       });
 
     });


### PR DESCRIPTION
Models generally expect to have access to the app object, but if they're constructed from the options passed to a view they're currently missing the app. This is a quick fix for that by passing options.app (which is required) to the modelUtils.getModel function.
