### PR TITLE
changed getTemplateData to also include the view options in the template

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -106,7 +106,7 @@ module.exports = BaseView = Backbone.View.extend({
    * Try to return proper data if model or collection is available.
    */
   getTemplateData: function() {
-    var retVal;
+    var retVal, parsedOptions;
 
     if (this.model) {
       retVal = this.model.toJSON();
@@ -118,7 +118,9 @@ module.exports = BaseView = Backbone.View.extend({
       };
     }
 
-    return _.extend({}, retVal, this.options);
+    // Remove options that are duplicates in the templates
+    parsedOptions = _.omit(this.options, ['model', 'collection', 'app']);
+    return _.extend({}, retVal, parsedOptions);
   },
 
   /**

--- a/test/client/base_view.test.js
+++ b/test/client/base_view.test.js
@@ -204,6 +204,13 @@ describe('Base/View', function () {
       expect(this.subject.getTemplateData()).to.not.equal(this.subject.options);
     });
 
+    it('should remove app from the templateData', function() {
+      this.subject.options.app = this.app;
+      expect(this.subject.getTemplateData()).to.deep.equal({
+        test: 'test'
+      });
+    });
+
     context('there is a model', function () {
       beforeEach(function () {
         this.subject.model = new Model({
@@ -225,6 +232,15 @@ describe('Base/View', function () {
           test: 'test'
         });
       });
+
+      it('should remove the model from the options', function() {
+        this.subject.options.model = this.subject.model;
+
+        expect(this.subject.getTemplateData()).to.deep.equal({
+          myOption: 'test',
+          test: 'test'
+        });
+      });
     });
 
     context('there is a collection', function () {
@@ -243,6 +259,17 @@ describe('Base/View', function () {
       });
 
       it('should return the models, collection meta information, and params with the options', function () {
+        expect(this.subject.getTemplateData()).to.deep.equal({
+          models: [collectionModel],
+          meta: collectionMeta,
+          params: collectionParams,
+          test: 'test'
+        });
+      });
+
+      it('should remove "collection" from the options', function() {
+        this.subject.options.collection = this.subject.collection;
+
         expect(this.subject.getTemplateData()).to.deep.equal({
           models: [collectionModel],
           meta: collectionMeta,


### PR DESCRIPTION
Pretty much what the title says, pretty quick simple change.  This allows us to set an option in a template, and have that information passed into sub-templates, without having to specifically pick and choose options per subview.
