### PR TITLE
make model/collection parsing an option in parseModelAndCollection

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -66,7 +66,7 @@ module.exports = BaseView = Backbone.View.extend({
       this.parentView = options.parentView;
     }
 
-    options = BaseView.parseModelAndCollection(this.app.modelUtils, options);
+    options = BaseView.parseModelAndCollection(this.app.modelUtils, _.extend({ parse: true }, options));
     this.model = options.model;
     this.collection = options.collection;
   },
@@ -491,7 +491,7 @@ BaseView.parseModelAndCollection = function(modelUtils, options) {
   if (options.model != null) {
     if (!(options.model instanceof Backbone.Model) && options.model_name) {
       options.model = modelUtils.getModel(options.model_name, options.model, {
-        parse: true,
+        parse: options.parse,
         app: options.app
       });
     }
@@ -502,7 +502,7 @@ BaseView.parseModelAndCollection = function(modelUtils, options) {
   if (options.collection != null) {
     if (!(options.collection instanceof Backbone.Collection) && options.collection_name) {
       options.collection = modelUtils.getCollection(options.collection_name, options.collection, {
-        parse: true,
+        parse: options.parse,
         app: options.app,
         params: options.collection_params
       });

--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -491,7 +491,7 @@ BaseView.parseModelAndCollection = function(modelUtils, options) {
   if (options.model != null) {
     if (!(options.model instanceof Backbone.Model) && options.model_name) {
       options.model = modelUtils.getModel(options.model_name, options.model, {
-        parse: options.parse,
+        parse: !!options.parse,
         app: options.app
       });
     }
@@ -502,7 +502,7 @@ BaseView.parseModelAndCollection = function(modelUtils, options) {
   if (options.collection != null) {
     if (!(options.collection instanceof Backbone.Collection) && options.collection_name) {
       options.collection = modelUtils.getCollection(options.collection_name, options.collection, {
-        parse: options.parse,
+        parse: !!options.parse,
         app: options.app,
         params: options.collection_params
       });

--- a/test/shared/base/view.test.js
+++ b/test/shared/base/view.test.js
@@ -165,10 +165,10 @@ describe('BaseView', function() {
       view.parentView.should.equal('test');
     });
 
-    it('should invoke parseModelAndCollection', function () {
+    it('should invoke parseModelAndCollection with the parse option', function () {
       var spy = sinon.spy(BaseView, 'parseModelAndCollection');
       view.parseOptions({ app: this.app });
-      spy.should.have.been.called.once;
+      spy.should.have.been.calledWith(this.app.modelUtils, { app: this.app, parse: true }).once;
       BaseView.parseModelAndCollection.restore()
     });
 
@@ -271,13 +271,14 @@ describe('BaseView', function() {
         });
 
         it('it should create an instance of the model', function () {
-          var result = BaseView.parseModelAndCollection(modelUtils, { model: modelData, model_name: 'MyModel', app: this.app });
+          var result = BaseView.parseModelAndCollection(modelUtils, { model: modelData, model_name: 'MyModel', app: this.app, parse: true });
 
           result.should.deep.equal({
             model_name: 'MyModel',
             model_id: 101,
             model: modelInstance,
-            app: this.app
+            app: this.app,
+            parse: true
           });
         });
       });
@@ -325,13 +326,14 @@ describe('BaseView', function() {
         });
 
         it('it should create an instance of the collection', function () {
-          var result = BaseView.parseModelAndCollection(modelUtils, { collection: [], collection_name: 'MyCollection', app: this.app, collection_params: params });
+          var result = BaseView.parseModelAndCollection(modelUtils, { collection: [], collection_name: 'MyCollection', app: this.app, collection_params: params, parse: true });
 
           result.should.deep.equal({
             collection_name: 'MyCollection',
             collection_params: params,
             collection: collection,
-            app: this.app
+            app: this.app,
+            parse: true
           });
         });
       });

--- a/test/shared/base/view.test.js
+++ b/test/shared/base/view.test.js
@@ -281,8 +281,14 @@ describe('BaseView', function() {
             parse: true
           });
         });
-      });
 
+        context('options do not contain parse: true', function () {
+          it('it should not pass parse: true to modelUtils', function () {
+            modelUtilsMock.expects("getModel").withArgs('MyModel', modelData, { parse: false, app: this.app }).returns(modelInstance);
+            BaseView.parseModelAndCollection(modelUtils, { model: modelData, model_name: 'MyModel', app: this.app });
+          });
+        });
+      });
     });
 
     context('there is a collection', function () {
@@ -334,6 +340,13 @@ describe('BaseView', function() {
             collection: collection,
             app: this.app,
             parse: true
+          });
+        });
+
+        context('options do not contain parse: true', function () {
+          it('it should not pass parse: true to modelUtils', function () {
+            modelUtilsMock.expects("getCollection").withArgs('MyCollection', [], { parse: false, app: this.app, params: params }).returns(collection);
+            BaseView.parseModelAndCollection(modelUtils, { collection: [], collection_name: 'MyCollection', app: this.app, collection_params: params });
           });
         });
       });


### PR DESCRIPTION
When parseModelAndCollection is called by the rendr-handlebars `view` method on the client-side there is not an app option present, so if the models parse method uses this.app it will error. Beyond that it seems unnecessary to call parse in this use-case which is just constructing the fetch summary for the placeholder div.

We do want the model/collection to be instantiated using parse when the view is attached, so pass `{ parse: true }` explicitly from `parseOptions`

@saponifi3d @mattpardee @mrubens