### PR TITLE
move the refresh to live in parseOptions to make sure it works after hydration

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -21,12 +21,9 @@ function noop() {}
 
 module.exports = BaseView = Backbone.View.extend({
   constructor: function(options) {
-    var obj;
-
     this.options = _.extend( this.options || {}, options || {} );
 
     this.parseOptions(options);
-
     this.name = this.name || this.app.modelUtils.underscorize(this.constructor.id || this.constructor.name);
 
     // parseOptions deals w/ models and collections, but the BaseView will override those changes
@@ -35,10 +32,6 @@ module.exports = BaseView = Backbone.View.extend({
     if (this.postInitialize) {
       console.warn('`postInitialize` is deprecated, please use `initialize`');
       this.postInitialize();
-    }
-
-    if ((obj = this.options.model || this.options.collection) && this.renderOnRefresh) {
-      obj.on('refresh', this.render, this);
     }
 
     this.render = this.render.bind(this);
@@ -54,6 +47,7 @@ module.exports = BaseView = Backbone.View.extend({
     /**
      * Populate `this.options` and alias as `options`.
      */
+    var obj;
     options = _.extend(this.options, options || {});
 
     if (options.app != null) {
@@ -69,6 +63,10 @@ module.exports = BaseView = Backbone.View.extend({
     options = BaseView.parseModelAndCollection(this.app.modelUtils, options);
     this.model = options.model;
     this.collection = options.collection;
+
+    if ((obj = this.model || this.collection) && this.renderOnRefresh) {
+      obj.on('refresh', this.render, this);
+    }
   },
 
   /**

--- a/test/shared/base/view.test.js
+++ b/test/shared/base/view.test.js
@@ -1,4 +1,6 @@
-var should = require('chai').should(),
+var chai = require('chai')
+    should = chai.should(),
+    expect = chai.expect,
     sinon = require('sinon'),
     _ = require('underscore'),
     BaseModel = require('../../../shared/base/model'),
@@ -199,6 +201,23 @@ describe('BaseView', function() {
       var options = { app: this.app, test: 'test' };
       view.parseOptions(options);
       view.options.should.deep.equal(options);
+    });
+
+    it('adds a refresh listener if rendrOnRefresh is set', function () {
+      var model = new BaseModel(),
+          options = { model: model };
+
+      view.renderOnRefresh = true;
+      view.parseOptions(options);
+      view.model._events.refresh.should.not.be.undefined;
+    });
+
+    it('no refresh listener if rendrOnRefresh is set to false', function () {
+      var model = new BaseModel(),
+          options = { model: model };
+
+      view.parseOptions(options);
+      expect(view.model._events.refresh).to.be.undefined;
     });
   });
 


### PR DESCRIPTION
basically what the title says.

it's a quick update of: https://github.com/rendrjs/rendr/pull/304 - and adds tests around it.