### PR TITLE
changed the rest adapter to return array query parameters without indices

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "url": "git://github.com/rendrjs/rendr.git"
   },
   "dependencies": {
-    "underscore": "~1.6.0",
-    "backbone": "1.1.2",
     "async": "~0.9.0",
-    "qs": "1.2.1",
+    "backbone": "1.1.2",
+    "debug": "*",
     "express": "~3",
-    "sanitizer": "~0.1",
+    "qs2": "~0.6.6",
     "request": "~2.40.0",
-    "debug": "*"
+    "sanitizer": "~0.1",
+    "underscore": "~1.6.0"
   },
   "devDependencies": {
     "chai": "1.8.1",

--- a/server/data_adapter/rest_adapter.js
+++ b/server/data_adapter/rest_adapter.js
@@ -4,7 +4,8 @@ var DataAdapter = require('./index'),
     url = require('url'),
     request,
     debug = require('debug')('rendr:RestAdapter'),
-    util = require('util');
+    util = require('util'),
+    qs = require('qs2');
 
 module.exports = RestAdapter;
 
@@ -109,7 +110,7 @@ RestAdapter.prototype.apiDefaults = function(api, req) {
 
   // If path contains a protocol, assume it's a URL.
   if (api.path && ~api.path.indexOf('://')) {
-    api.url = url.format({ pathname: api.path, query: api.query });
+    api.url = url.format({ pathname: api.path });
     delete api.path;
   }
 
@@ -117,9 +118,10 @@ RestAdapter.prototype.apiDefaults = function(api, req) {
   apiHost = this.options[api.api] || this.options['default'] || this.options;
 
   urlOpts = _.defaults(
-    _.pick(api,     ['protocol', 'port', 'query']),
+    _.pick(api,     ['protocol', 'port']),
     _.pick(apiHost, ['protocol', 'port', 'host', 'hostname'])
   );
+
   urlOpts.pathname = api.path || api.pathname;
 
   _.defaults(api, {
@@ -127,6 +129,10 @@ RestAdapter.prototype.apiDefaults = function(api, req) {
     url: url.format(urlOpts),
     headers: {}
   });
+
+  if (api.query) {
+    api.url += '?' + qs.stringify(api.query);
+  }
 
   // Add a default UserAgent, so some servers don't reject our request.
   if (api.headers['User-Agent'] == null) {

--- a/shared/syncer.js
+++ b/shared/syncer.js
@@ -21,7 +21,7 @@ var _ = require('underscore'),
 
 if (isServer) {
   // hide it from requirejs since it's server only
-  var serverOnly_qs = 'qs';
+  var serverOnly_qs = 'qs2';
   var qs = require(serverOnly_qs);
 } else {
   Backbone.$ = window.$ || require('jquery');

--- a/test/server/data_adapter/rest_adapter.test.js
+++ b/test/server/data_adapter/rest_adapter.test.js
@@ -201,6 +201,22 @@ describe('RestAdapter', function() {
       result.should.have.property('port', 3001);
     });
 
+    it('should use bracketed array queries', function() {
+      restAdapter.options.default = {
+        protocol: 'http',
+        host: 'example.com'
+      };
+
+      var api = {
+        path: '/v1/cats',
+        query: { q: [1, 3] },
+        body: {}
+      };
+
+      restAdapter.apiDefaults(api).should.have.property('url',
+        'http://example.com/v1/cats?q[]=1&q[]=3');
+    });
+
     it('should use a custom user agent', function () {
       var api = { headers: { 'User-Agent': 'custom user agent' }, body: {} };
 


### PR DESCRIPTION
Fix for: https://github.com/rendrjs/rendr/issues/416

Since most parsers can handle this syntax it seems like a better default, and `qs` parsers this syntax fine too.

@spikebrehm do you have any concerns about this?