### PR TITLE
rest adapter fix

### DIFF
--- a/server/data_adapter/rest_adapter.js
+++ b/server/data_adapter/rest_adapter.js
@@ -130,7 +130,7 @@ RestAdapter.prototype.apiDefaults = function(api, req) {
     headers: {}
   });
 
-  if (api.query) {
+  if (api.query && !_.isEmpty(api.query)) {
     api.url += '?' + qs.stringify(api.query);
   }
 

--- a/test/server/data_adapter/rest_adapter.test.js
+++ b/test/server/data_adapter/rest_adapter.test.js
@@ -217,6 +217,16 @@ describe('RestAdapter', function() {
         'http://example.com/v1/cats?q[]=1&q[]=3');
     });
 
+    it('should not add an extra ? if the query is an empty object', function () {
+      restAdapter.options.default = {
+        host: 'example.com',
+        protocol: 'https',
+        query: {}
+      };
+
+      restAdapter.apiDefaults({body: {}}).should.have.property('url', 'https://example.com');
+    });
+
     it('should use a custom user agent', function () {
       var api = { headers: { 'User-Agent': 'custom user agent' }, body: {} };
 


### PR DESCRIPTION
seems like there are cases where the query param is an empty object, checking to make sure it's not empty before adding a `?` too.