### PR TITLE
make sure the fetcher creates the correct collection in the store.

### DIFF
--- a/shared/fetcher.js
+++ b/shared/fetcher.js
@@ -47,7 +47,7 @@ Fetcher.prototype.getModelOrCollectionForSpec = function(spec, attrsOrModels, op
  * Returns an instance of Collection.
  */
 Fetcher.prototype.getCollectionForSpec = function(spec, models, options, callback) {
-  var collectionOptions = this.buildOptions(options, spec.params);
+  var collectionOptions = this.buildOptions(options, _.extend({params: spec.params}, spec.params));
   models = models || [];
   return this.modelUtils.getCollection(spec.collection, models, collectionOptions, callback);
 };

--- a/test/shared/fetcher.test.js
+++ b/test/shared/fetcher.test.js
@@ -654,4 +654,19 @@ describe('fetcher', function() {
       this.expectedModel.should.deep.equal(fetcher.retrieveModels('Listing', [1])[0])
     });
   });
+
+  describe('getCollectionForSpec', function () {
+    var spec, params;
+
+    beforeEach(function () {
+      params = { name: 'test' }
+      spec = { collection: 'Listings', params: params };
+    });
+
+    it('the options should include a `params` attribute for the collection store', function () {
+      var result = fetcher.getCollectionForSpec(spec);
+      expect(result.params).to.deep.equal(params);
+      expect(result.options.params).to.deep.equal(params);
+    });
+  });
 });


### PR DESCRIPTION
The fetcher was creating two collections for lazy loaded views, one without parameters and one with parameters.  This fix will make sure the first collection has the correct params, so it's not creating a second instance in the store when calling the `fetch` function when lazy loading the view.