### PR TITLE
Fix some missed usages of $

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -442,11 +442,11 @@ BaseView.getViewOptions = function ($el) {
 
 BaseView.attach = function(app, parentView, callback) {
   var scope = parentView ? parentView.$el : null,
-      list = $('[data-view]', scope).toArray();
+      list = Backbone.$('[data-view]', scope).toArray();
 
   async.map(list, function(el, cb) {
     var $el, options, viewName, fetchSummary;
-    $el = $(el);
+    $el = Backbone.$(el);
     if (!$el.data('view-attached')) {
       options = BaseView.getViewOptions($el);
       options.app = app;


### PR DESCRIPTION
There was some jQuery cleanup of $ usages in 4d349499b72210a3ec96a49e7a9288c9d3300bd9, but a couple of usages got missed.  This fixes those missed $ usages.