### PR TITLE
Dependency injection

### DIFF
--- a/shared/app.js
+++ b/shared/app.js
@@ -56,8 +56,12 @@ module.exports = Backbone.Model.extend({
      * We can't use `this.get('templateAdapter')` here because `Backbone.Model`'s
      * constructor has not yet been called.
      */
-    var templateAdapterModule = attributes.templateAdapter || this.defaults.templateAdapter;
-    this.templateAdapter = require(templateAdapterModule)({entryPath: entryPath});
+    if (attributes.templateAdapterInstance) {
+      this.templateAdapter = attributes.templateAdapterInstance;
+    } else {
+      var templateAdapterModule = attributes.templateAdapter || this.defaults.templateAdapter;
+      this.templateAdapter = require(templateAdapterModule)({entryPath: entryPath});
+    }
 
     /**
      * Instantiate the `Fetcher`, which is used on client and server.

--- a/shared/app.js
+++ b/shared/app.js
@@ -6,7 +6,8 @@
 var Backbone = require('backbone'),
     Fetcher = require('./fetcher'),
     ModelUtils = require('./modelUtils'),
-    isServer = (typeof window === 'undefined');
+    isServer = (typeof window === 'undefined'),
+    defaultRouterModule = 'app/router';
 
 if (!isServer) {
   Backbone.$ = window.$ || require('jquery');
@@ -72,7 +73,7 @@ module.exports = Backbone.Model.extend({
      * Initialize the `ClientRouter` on the client-side.
      */
     if (!isServer) {
-      var ClientRouter = options.ClientRouter || require('app/router');
+      var ClientRouter = options.ClientRouter || require(defaultRouterModule);
 
       new ClientRouter({
         app: this,

--- a/shared/app.js
+++ b/shared/app.js
@@ -54,8 +54,8 @@ module.exports = Backbone.Model.extend({
      * We can't use `this.get('templateAdapter')` here because `Backbone.Model`'s
      * constructor has not yet been called.
      */
-    if (attributes.templateAdapterInstance) {
-      this.templateAdapter = attributes.templateAdapterInstance;
+    if (options.templateAdapterInstance) {
+      this.templateAdapter = options.templateAdapterInstance;
     } else {
       var templateAdapterModule = attributes.templateAdapter || this.defaults.templateAdapter;
       this.templateAdapter = require(templateAdapterModule)({entryPath: entryPath});
@@ -72,7 +72,7 @@ module.exports = Backbone.Model.extend({
      * Initialize the `ClientRouter` on the client-side.
      */
     if (!isServer) {
-      var ClientRouter = attributes.ClientRouter || require('app/router');
+      var ClientRouter = options.ClientRouter || require('app/router');
 
       new ClientRouter({
         app: this,

--- a/shared/app.js
+++ b/shared/app.js
@@ -55,7 +55,7 @@ module.exports = Backbone.Model.extend({
      * We can't use `this.get('templateAdapter')` here because `Backbone.Model`'s
      * constructor has not yet been called.
      */
-    if (options.templateAdapterInstance) {
+    if (this.options.templateAdapterInstance) {
       this.templateAdapter = options.templateAdapterInstance;
     } else {
       var templateAdapterModule = attributes.templateAdapter || this.defaults.templateAdapter;
@@ -73,7 +73,7 @@ module.exports = Backbone.Model.extend({
      * Initialize the `ClientRouter` on the client-side.
      */
     if (!isServer) {
-      var ClientRouter = options.ClientRouter || require(defaultRouterModule);
+      var ClientRouter = this.options.ClientRouter || require(defaultRouterModule);
 
       new ClientRouter({
         app: this,

--- a/shared/app.js
+++ b/shared/app.js
@@ -6,11 +6,9 @@
 var Backbone = require('backbone'),
     Fetcher = require('./fetcher'),
     ModelUtils = require('./modelUtils'),
-    isServer = (typeof window === 'undefined'),
-    ClientRouter;
+    isServer = (typeof window === 'undefined');
 
 if (!isServer) {
-  ClientRouter = require('app/router');
   Backbone.$ = window.$ || require('jquery');
 }
 
@@ -74,6 +72,8 @@ module.exports = Backbone.Model.extend({
      * Initialize the `ClientRouter` on the client-side.
      */
     if (!isServer) {
+      var ClientRouter = attributes.ClientRouter || require('app/router');
+
       new ClientRouter({
         app: this,
         entryPath: entryPath,

--- a/test/fixtures/app/template_adapter.js
+++ b/test/fixtures/app/template_adapter.js
@@ -1,0 +1,6 @@
+module.exports = function (options) {
+  return {
+    name: 'Test template adapter',
+    suppliedOptions: options
+  };
+}

--- a/test/shared/app.test.js
+++ b/test/shared/app.test.js
@@ -26,4 +26,41 @@ describe('BaseApp', function() {
       new MyApp();
     });
   });
+
+  describe('constructor', function() {
+    context('with a custom templateAdapter module name', function() {
+      beforeEach(function () {
+        this.attributes = {templateAdapter: '../test/fixtures/app/template_adapter'};
+      });
+
+      it('creates the templateAdapter we specify', function() {
+        var app = new App(this.attributes);
+
+        expect(app.templateAdapter).to.have.property('name', 'Test template adapter');
+      });
+
+      it('supplies the entryPath to the template adapter', function() {
+        var app = new App(this.attributes, {entryPath: 'myEntryPath'});
+
+        expect(app.templateAdapter).to.have.deep.property('suppliedOptions.entryPath', 'myEntryPath');
+      });
+    });
+
+    context('with a concrete templateAdapterInstance', function() {
+      it('uses the supplied templateAdapterInstance', function() {
+        var myTemplateAdapter = {};
+        var app = new App(null, {templateAdapterInstance: myTemplateAdapter});
+
+        expect(app.templateAdapter).to.equal(myTemplateAdapter);
+      });
+
+      it('does not try to require a template adapter by name', function () {
+        new App({
+          templateAdapter: 'non existent module name - should throw'
+        }, {
+          templateAdapterInstance: {}
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
I'd like to be able to inject pre-`require`d modules for `templateAdapter` and `ClientRouter` so that I don't have to `expose` them through Browserify config, in order for Rendr to require them for me. These optional attribute values should enable that use case without breaking any existing usages.