### PR TITLE
Add callback to bootstrapData

### DIFF
--- a/shared/app.js
+++ b/shared/app.js
@@ -98,8 +98,8 @@ module.exports = Backbone.Model.extend({
   /**
    * @client
    */
-  bootstrapData: function(modelMap) {
-    this.fetcher.bootstrapData(modelMap);
+  bootstrapData: function(modelMap, callback) {
+    this.fetcher.bootstrapData(modelMap, callback);
   },
 
   /**

--- a/shared/fetcher.js
+++ b/shared/fetcher.js
@@ -235,9 +235,8 @@ Fetcher.prototype.bootstrapData = function(modelMap, callback) {
       cb(null);
     });
   }, function(err) {
-    fetcher.storeResults(results);
     if (_.isFunction(callback)) {
-      callback();
+      callback(results);
     }
   });
 };

--- a/shared/fetcher.js
+++ b/shared/fetcher.js
@@ -224,7 +224,7 @@ Fetcher.prototype.storeResults = function(results) {
   });
 };
 
-Fetcher.prototype.bootstrapData = function(modelMap) {
+Fetcher.prototype.bootstrapData = function(modelMap, callback) {
   var results = {},
       fetcher = this;
 
@@ -236,6 +236,9 @@ Fetcher.prototype.bootstrapData = function(modelMap) {
     });
   }, function(err) {
     fetcher.storeResults(results);
+    if (_.isFunction(callback)) {
+      callback();
+    }
   });
 };
 

--- a/test/shared/fetcher.test.js
+++ b/test/shared/fetcher.test.js
@@ -638,6 +638,28 @@ describe('fetcher', function() {
     });
   });
 
+  describe('bootstrapData', function() {
+    var attr, listingModel, bootstrapMockData;
+
+    beforeEach(function () {
+      attr = {id: 1, name: 'foobar', location: 'San Francisco'};
+      listingModel = new Listing(attr, {app: this.app});
+      bootstrapMockData = {'model':{'summary':{'model':'user','id':'1'},'data':{'name':'foobar', 'location': 'San Francisco'}}};
+    });
+
+    it('should call the callback function', function (done) {
+      var getModelOrCollectionForSpecSpy = sinon.spy(fetcher, 'getModelOrCollectionForSpec');
+
+      var bootstrapData = fetcher.bootstrapData(bootstrapMockData, function(results) {
+        results.should.be.an('object');
+        results.should.have.property('model');
+        results['model'].attributes.should.deep.equal(bootstrapMockData.model.data);
+        done();
+      });
+    });
+
+  });
+
   describe('retrieveModels', function() {
     var modelAttrs;
 


### PR DESCRIPTION
In AMD we need to call `App.start()` inside a callback on `bootstrapData` otherwise  `App.start()`  get called before the data get stored in the modelStore.
