### PR TITLE
fix for require -> requireAMD for non-CommonJS folks

### DIFF
--- a/shared/app.js
+++ b/shared/app.js
@@ -73,7 +73,7 @@ module.exports = Backbone.Model.extend({
      * Initialize the `ClientRouter` on the client-side.
      */
     if (!isServer) {
-      var ClientRouter = this.options.ClientRouter || require(defaultRouterModule);
+      var ClientRouter = this.options.ClientRouter || this.modelUtils._requireAMD(defaultRouterModule);
 
       new ClientRouter({
         app: this,


### PR DESCRIPTION
Quick fix for require vs requireAMD in the `shared/app.js`

- [ ] need to deal with the callback functions for requireAMD