### PR TITLE
allow routes to specify custom headers

### DIFF
--- a/server/router.js
+++ b/server/router.js
@@ -86,8 +86,9 @@ ServerRouter.prototype.getHandler = function(action, pattern, route) {
 
       res.render(viewPath, viewData, function(err, html) {
         if (err) return next(err);
+        res.type('html');
         res.set(router.getHeadersForRoute(route));
-        res.type('html').end(html);
+        res.end(html);
       });
     });
   };
@@ -102,8 +103,14 @@ ServerRouter.prototype.addExpressRoute = function(routeObj) {
 
 ServerRouter.prototype.getHeadersForRoute = function(definition) {
   var headers = {};
+
   if (definition.maxAge != null) {
     headers['Cache-Control'] = "public, max-age=" + definition.maxAge;
   }
+
+  if (definition.headers) {
+    _.extend(headers, definition.headers);
+  }
+
   return headers;
 };

--- a/test/server/router.test.js
+++ b/test/server/router.test.js
@@ -43,6 +43,19 @@ describe("server/router", function() {
 
       headers.should.deep.equal(expectedHeaders);
     })
+
+    it("should set other headers passed into the route's definition", function () {
+      var maxAge = 1000,
+          customHeaders = {
+            'Vary': 'User-Agent', 
+            'Cache-Control': 'no-transform,public,max-age=300,s-maxage=900',
+            'ETag': '12345678'
+          },
+        headers = this.router.getHeadersForRoute({headers: customHeaders, maxAge: maxAge});
+
+      headers.should.deep.equal(customHeaders);
+    })
+
   });
 
   describe("route", function() {


### PR DESCRIPTION
this PR has two motivations/changes:

1. In order to modify our `Content-Type` header to specify a charset,  we had to unchain the `res.type('html')` in `getHandler()` ( `type`'ll overwrite anything that's already been set).

1. Added a new attribute to the routes object `headers` to allow any headers to be passed in per route.  

