### PR TITLE
allow template finder option to be passed in within template adapter initialization

### DIFF
--- a/shared/app.js
+++ b/shared/app.js
@@ -49,19 +49,7 @@ module.exports = Backbone.Model.extend({
       this.req = this.options.req;
     }
 
-    /**
-     * Initialize the `templateAdapter`, allowing application developers to use whichever
-     * templating system they want.
-     *
-     * We can't use `this.get('templateAdapter')` here because `Backbone.Model`'s
-     * constructor has not yet been called.
-     */
-    if (this.options.templateAdapterInstance) {
-      this.templateAdapter = options.templateAdapterInstance;
-    } else {
-      var templateAdapterModule = attributes.templateAdapter || this.defaults.templateAdapter;
-      this.templateAdapter = require(templateAdapterModule)({entryPath: entryPath});
-    }
+    this.initializeTemplateAdapter(entryPath, attributes);
 
     /**
      * Instantiate the `Fetcher`, which is used on client and server.
@@ -87,6 +75,37 @@ module.exports = Backbone.Model.extend({
     }
 
     Backbone.Model.apply(this, arguments);
+  },
+
+  /**
+   * @shared
+   *
+   * Initialize the `templateAdapter`, allowing application developers to use whichever
+   * templating system they want.
+   *
+   * We can't use `this.get('templateAdapter')` here because `Backbone.Model`'s
+   * constructor has not yet been called.
+   */
+  initializeTemplateAdapter: function(entryPath, attributes) {
+    if (this.options.templateAdapterInstance) {
+      this.templateAdapter = this.options.templateAdapterInstance;
+    } else {
+      var templateAdapterModule = attributes.templateAdapter || this.defaults.templateAdapter,
+      templateAdapterOptions = {entryPath: entryPath};
+
+      templateAdapterOptions.templateFinder = this.getTemplateFinder();
+
+      this.templateAdapter = require(templateAdapterModule)(templateAdapterOptions);
+    }
+  },
+
+  /**
+   * @shared
+   * Noop
+   * override this in app/app returning custom template finder
+   */
+  getTemplateFinder: function() {
+    return null;
   },
 
   /**

--- a/shared/app.js
+++ b/shared/app.js
@@ -4,6 +4,7 @@
  */
 
 var Backbone = require('backbone'),
+    _ = require('underscore'),
     Fetcher = require('./fetcher'),
     ModelUtils = require('./modelUtils'),
     isServer = (typeof window === 'undefined'),
@@ -104,9 +105,7 @@ module.exports = Backbone.Model.extend({
    * Noop
    * override this in app/app returning custom template finder
    */
-  getTemplateFinder: function() {
-    return null;
-  },
+  getTemplateFinder: _.noop,
 
   /**
    * @shared

--- a/shared/app.js
+++ b/shared/app.js
@@ -94,18 +94,26 @@ module.exports = Backbone.Model.extend({
       var templateAdapterModule = attributes.templateAdapter || this.defaults.templateAdapter,
       templateAdapterOptions = {entryPath: entryPath};
 
-      templateAdapterOptions.templateFinder = this.getTemplateFinder();
-
+      templateAdapterOptions = this.setTemplateFinder(templateAdapterOptions);
       this.templateAdapter = require(templateAdapterModule)(templateAdapterOptions);
     }
   },
 
   /**
    * @shared
-   * Noop
-   * override this in app/app returning custom template finder
+   * Override this in app/app to return a custom template finder
    */
   getTemplateFinder: _.noop,
+
+  /**
+   * @shared
+   */
+  setTemplateFinder: function(templateAdapterOptions) {
+    if (_.isFunction(this.getTemplateFinder) && this.getTemplateFinder !== _.noop) {
+      templateAdapterOptions.templateFinder = this.getTemplateFinder();
+    }
+    return templateAdapterOptions;
+  },
 
   /**
    * @shared

--- a/test/shared/app.test.js
+++ b/test/shared/app.test.js
@@ -91,7 +91,7 @@ describe('BaseApp', function() {
     it('returns null', function() {
       var app = new App(null, {});
       var templateFinder = app.getTemplateFinder();
-      expect(templateFinder).to.be.null;
+      expect(templateFinder).to.be.undefined;
     });
 
   });

--- a/test/shared/app.test.js
+++ b/test/shared/app.test.js
@@ -28,6 +28,46 @@ describe('BaseApp', function() {
   });
 
   describe('constructor', function() {
+
+    it('calls the initializeTemplateAdapter method with proper arguments', function() {
+      var myTemplateAdapter = {};
+      var MyApp = App.extend({
+        initializeTemplateAdapter: sinon.spy()
+      });
+      var app = new MyApp(null, {templateAdapterInstance: myTemplateAdapter, entryPath: 'entryPath'});
+
+      app.initializeTemplateAdapter.should.have.been.calledWith('entryPath', {});
+    });
+  });
+
+  describe('initializeTemplateAdapter', function() {
+    context('with a concrete templateAdapterInstance', function() {
+
+      it('uses the supplied templateAdapterInstance', function() {
+        var myTemplateAdapter = {};
+        var app = new App(null, {templateAdapterInstance: myTemplateAdapter});
+
+        expect(app.templateAdapter).to.equal(myTemplateAdapter);
+      });
+
+      it('does not try to require a template adapter by name', function () {
+        new App({
+          templateAdapter: 'non existent module name - should throw'
+        }, {
+          templateAdapterInstance: {}
+        });
+      });
+
+      it('calls setTemplateFinder', function() {
+        var MyApp = App.extend({
+          getTemplateFinder: sinon.spy()
+        });
+        var app = new MyApp(null, {});
+
+        app.getTemplateFinder.should.have.been.called;
+      });
+    });
+
     context('with a custom templateAdapter module name', function() {
       beforeEach(function () {
         this.attributes = {templateAdapter: '../test/fixtures/app/template_adapter'};
@@ -45,22 +85,14 @@ describe('BaseApp', function() {
         expect(app.templateAdapter).to.have.deep.property('suppliedOptions.entryPath', 'myEntryPath');
       });
     });
+  });
 
-    context('with a concrete templateAdapterInstance', function() {
-      it('uses the supplied templateAdapterInstance', function() {
-        var myTemplateAdapter = {};
-        var app = new App(null, {templateAdapterInstance: myTemplateAdapter});
-
-        expect(app.templateAdapter).to.equal(myTemplateAdapter);
-      });
-
-      it('does not try to require a template adapter by name', function () {
-        new App({
-          templateAdapter: 'non existent module name - should throw'
-        }, {
-          templateAdapterInstance: {}
-        });
-      });
+  describe('getTemplateFinder', function() {
+    it('returns null', function() {
+      var app = new App(null, {});
+      var templateFinder = app.getTemplateFinder();
+      expect(templateFinder).to.be.null;
     });
+
   });
 });

--- a/test/shared/app.test.js
+++ b/test/shared/app.test.js
@@ -1,6 +1,7 @@
 var sinon = require('sinon'),
     should = require('chai').should(),
-    App = require('../../shared/app');
+    App = require('../../shared/app'),
+    _ = require('underscore');
 
 describe('BaseApp', function() {
   describe('initialize', function() {
@@ -57,15 +58,6 @@ describe('BaseApp', function() {
           templateAdapterInstance: {}
         });
       });
-
-      it('calls setTemplateFinder', function() {
-        var MyApp = App.extend({
-          getTemplateFinder: sinon.spy()
-        });
-        var app = new MyApp(null, {});
-
-        app.getTemplateFinder.should.have.been.called;
-      });
     });
 
     context('with a custom templateAdapter module name', function() {
@@ -93,6 +85,52 @@ describe('BaseApp', function() {
       var templateFinder = app.getTemplateFinder();
       expect(templateFinder).to.be.undefined;
     });
+  });
 
+  describe('setTemplateFinder', function() {
+    it('calls getTemplatefinder', function() {
+      var MyApp = App.extend({
+        getTemplateFinder: sinon.spy()
+      });
+      var app = new MyApp(null, {});
+
+      app.getTemplateFinder.should.have.been.called;
+    });
+
+    context('if getTemplateFinder is a function and not noop', function() {
+      it('sets the templateFinder option correctly', function() {
+        var myTemplateFinder = {templatePatterns: []};
+        var MyApp = App.extend({
+          getTemplateFinder: function() {return myTemplateFinder;}
+        });
+        var app = new MyApp(null, {});
+
+        var templateAdapterOptions = app.setTemplateFinder({});
+        expect(templateAdapterOptions.templateFinder).to.be.deep.equal(myTemplateFinder);
+      });
+    });
+
+    context('if getTemplateFinder is not a function or is noop', function() {
+      it('leaves the option templateFinder undefined', function() {
+        var MyApp = App.extend({
+          getTemplateFinder: 'myGetTemplateFinder'
+        });
+        var app = new MyApp(null, {});
+        var templateAdapterOptions = app.setTemplateFinder({});
+        expect(templateAdapterOptions.templateFinder).to.be.undefined;
+      });
+    });
+
+    context('if getTemplateFinder is not a function or is noop', function() {
+      it('leaves the option templateFinder undefined', function() {
+        var MyApp = App.extend({
+          getTemplateFinder: _.noop
+        });
+        var app = new MyApp(null, {});
+
+        var templateAdapterOptions = app.setTemplateFinder({});
+        expect(templateAdapterOptions.templateFinder).to.be.undefined;
+      });
+    });
   });
 });


### PR DESCRIPTION
Since https://github.com/rendrjs/rendr-handlebars/pull/51, rendr-handlebars allows a custom templateFinder as an option.
These changes allow to easily pass that in from the Rendr side, breaking down a little bit the App constructor into smaller pieces, allowing for easy overriding.

Thoughts?