### PR TITLE
Allow custom base layout name

### DIFF
--- a/server/middleware/initApp.js
+++ b/server/middleware/initApp.js
@@ -25,6 +25,7 @@ module.exports = function(appAttributes, options) {
        */
       req: req,
       entryPath: options.entryPath,
+      baseLayoutName: options.baseLayoutName,
       modelUtils: options.modelUtils
     };
 

--- a/server/server.js
+++ b/server/server.js
@@ -111,6 +111,7 @@ Server.prototype.configure = function(fn) {
   this.expressApp.use(this.initApp(this.options.appData, {
     apiPath: this.options.apiPath,
     entryPath: this.options.entryPath,
+    baseLayoutName: this.options.baseLayoutName,
     modelUtils: this.options.modelUtils
   }));
 

--- a/server/viewEngine.js
+++ b/server/viewEngine.js
@@ -42,14 +42,20 @@ ViewEngine.prototype.renderWithLayout = function renderWithLayout(locals, app, c
  * Cache layout template function.
  */
 ViewEngine.prototype.getLayoutTemplate = function getLayoutTemplate(app, callback) {
+  var baseLayoutName = this.getBaseLayoutName(app);
+
   if (layoutTemplates[app.options.entryPath]) {
     return callback(null, layoutTemplates[app.options.entryPath]);
   }
-  app.templateAdapter.getLayout('__layout', app.options.entryPath, function(err, template) {
+  app.templateAdapter.getLayout(baseLayoutName, app.options.entryPath, function(err, template) {
     if (err) return callback(err);
     layoutTemplates[app.options.entryPath] = template;
     callback(err, template);
   });
+};
+
+ViewEngine.prototype.getBaseLayoutName = function getBaseLayoutName(app) {
+  return app.options.baseLayoutName ? app.options.baseLayoutName : '__layout';
 };
 
 ViewEngine.prototype.getViewHtml = function getViewHtml(viewPath, locals, app) {

--- a/test/server/middleware/initApp.test.js
+++ b/test/server/middleware/initApp.test.js
@@ -48,12 +48,14 @@ describe('initApp', function() {
         var options = {
             entryPath: 'fake/',
             modelUtils: {},
-            apiPath: 'MyApiPath'
+            apiPath: 'MyApiPath',
+            baseLayoutName: 'layout'
           },
           expectedAppOptions = {
             entryPath: 'fake/',
             modelUtils: {},
-            req: req
+            req: req,
+            baseLayoutName: 'layout'
           };
 
         middleware = initApp(null, options);

--- a/test/server/server.test.js
+++ b/test/server/server.test.js
@@ -77,7 +77,8 @@ describe('server/server', function() {
       var expectedOptions = {
         apiPath: server.options.apiPath,
         entryPath: server.options.entryPath,
-        modelUtils: server.options.modelUtils
+        modelUtils: server.options.modelUtils,
+        baseLayoutName: server.options.baseLayoutName
       };
 
       server.configure();

--- a/test/server/viewEngine.test.js
+++ b/test/server/viewEngine.test.js
@@ -107,4 +107,22 @@ describe('ViewEngine', function() {
       data.should.deep.equal({});
     });
   });
+
+  describe('getBaseLayoutName', function() {
+    context('a baseLayoutName is provided', function() {
+      it('it should return the value of baseLayoutName', function() {
+        app = {options: {baseLayoutName: 'myLayout'}};
+        var baseLayoutName = viewEngine.getBaseLayoutName(app);
+        baseLayoutName.should.be.deep.equal('myLayout');
+      });
+    });
+
+    context('a baseLayoutName is provided', function() {
+      it('it should return __layout', function() {
+        app = {options: {baseLayoutName: undefined}};
+        var baseLayoutName = viewEngine.getBaseLayoutName(app);
+        baseLayoutName.should.be.deep.equal('__layout');
+      });
+    });
+  });
 });


### PR DESCRIPTION
This adds flexibility allowing us to use a base layout with a name different from `__layout`, which is currently hardcoded into `viewEngine`. 
Using a custom template name will be as simple as doing this during the Rendr server creation:

```
var server = rendr.createServer({
  baseLayoutName: 'myTemplate'
});
```

Rendr-handlebars is already flexible enough to allow this.