### PR TITLE
add ability to pass fetch_options for a lazy fetch

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -226,6 +226,7 @@ module.exports = BaseView = Backbone.View.extend({
    */
   fetchLazy: function() {
     var params = {},
+        fetchOptions,
         fetchSpec;
 
     if (this.options.fetch_params) {
@@ -236,6 +237,14 @@ module.exports = BaseView = Backbone.View.extend({
       params = this.options.fetch_params;
     } else if (this.options.param_name) {
       params[this.options.param_name] = this.options.param_value;
+    }
+
+    if (this.options.fetch_options) {
+      if (!_.isObject(this.options.fetch_options)) {
+        throw new Error('fetch_options must be an object for lazy loaded views')
+      }
+
+      fetchOptions = this.options.fetch_options;
     }
 
     if (this.options.model_id != null) {
@@ -261,7 +270,7 @@ module.exports = BaseView = Backbone.View.extend({
     this.setLoading(true);
 
     this._preRender();
-    this.app.fetch(fetchSpec, this._fetchLazyCallback.bind(this));
+    this.app.fetch(fetchSpec, fetchOptions, this._fetchLazyCallback.bind(this));
   },
 
   _fetchLazyCallback: function(err, results) {

--- a/shared/fetcher.js
+++ b/shared/fetcher.js
@@ -163,7 +163,7 @@ Fetcher.prototype.isMissingKeys = function(modelData, keys) {
 };
 
 Fetcher.prototype.fetchFromApi = function(spec, options, callback) {
-  var model = this.getModelOrCollectionForSpec(spec),
+  var model = this.getModelOrCollectionForSpec(spec, null, options),
       fetcher = this;
 
   model.fetch({

--- a/test/shared/base/view.test.js
+++ b/test/shared/base/view.test.js
@@ -238,6 +238,40 @@ describe('BaseView', function() {
     });
   });
 
+  describe('fetchLazy', function () {
+    var fetchParams = { model: 'Foo' },
+        fetchOptions = { readFromCache: false },
+        modelName = 'MyModel',
+        MyView,
+        view,
+        fetchSpec;
+
+    beforeEach(function () {
+      fetchSpec = {
+        model: {
+          model: modelName,
+          params: fetchParams
+        }
+      };
+
+      MyView = BaseView.extend({ name: 'A View Name' });
+      myView = new MyView({
+        'app': { fetch: sinon.stub() },
+        'model_name': modelName,
+        'fetch_params': fetchParams,
+        'fetch_options': fetchOptions
+      });
+
+      myView.setLoading = sinon.stub();
+      myView._preRender = sinon.stub();
+      myView.fetchLazy();
+    });
+
+    it('passes the fetchSpec and fetch_options to the fetch call', function () {
+      expect(myView.app.fetch).to.have.been.calledWith(fetchSpec, fetchOptions, sinon.match.func);
+    });
+  });
+
   describe('parseModelAndCollection', function () {
     context('there is a model', function () {
       var MyModel = BaseModel.extend({}),


### PR DESCRIPTION
This PR introduces the ability to use the option `fetch_options` when lazy-loading a view to pass options to the `.fetch` call.

Additionally, I noticed that the options that the `fetch` method sets by default (specifically `readFromCache` and `writeToCache`) are not being added to the model's `options` hash because the options provided are not being passed down to the `getModelOrCollectionForSpec` call.  I made the change here to pass those options along as well.