### PR TITLE
inject a templateEngine param to the template adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ You can tell Rendr which Template Engine to use.  This represents the node-modul
 
 module.exports = BaseApp.extend({
   defaults: {
-    templateEngine: 'jade'
+    templateEngine: 'handlebars'
   }
 
 });

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ rendr.configure(function(expressApp) {
 
 ### Template Adapters
 
-Provides a way for Rendr to utilize custom html template engines.  Rendr's [ViewEngine](https://github.com/rendrjs/rendr/blob/master/server/viewEngine.js) will delegate to the [Template Adapter](https://github.com/rendrjs/rendr-handlebars/blob/master/index.js). You can build your own to provide your template engine of choice (i.e. Jade, Underscore templates, etc).
+Provides a way for Rendr to utilize custom html template engines (see also Template Engines section below).  Rendr's [ViewEngine](https://github.com/rendrjs/rendr/blob/master/server/viewEngine.js) will delegate to the [Template Adapter](https://github.com/rendrjs/rendr-handlebars/blob/master/index.js). You can build your own to provide your template engine of choice (i.e. Jade, Underscore templates, etc).
 
 ####Available Template Adapters
 
@@ -312,6 +312,42 @@ module.exports = BaseApp.extend({
 
 ```
 
+### Template Engines
+
+While Template Adapters provide the layer of abstraction that allow you to use your favorite template engine in a Rendr app, the Template Engine option itself will tell the app which version to use exactly. 
+The default is set to be Handlebars, which is currently supported by the Rendr-handlebars adapter until version 2.0.0.
+**When setting up your Rendr app, you'll need to add your Template Engine of choice to package.json.**
+ 
+E.g.
+ 
+```js
+// /package.json
+
+"dependencies": {
+  ...
+  "express": "^4.12.0",
+  "handlebars": "^2.0.0"
+  "qs2": "~0.6.6",
+  ...
+},
+  
+```
+
+####Using Custom Template Engines
+
+You can tell Rendr which Template Engine to use.  This represents the node-module that contains the engine.
+
+```js
+// /app/app.js
+
+module.exports = BaseApp.extend({
+  defaults: {
+    templateEngine: 'jade'
+  }
+
+});
+
+```
 
 ### Express middleware
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "chai": "^2.3.0",
     "coveralls": "~2.11.2",
+    "handlebars": "^2.0.0",
     "istanbul": "~0.3.13",
     "jquery": "^2.1.4",
     "jsdom": "^3.1.0",

--- a/shared/app.js
+++ b/shared/app.js
@@ -19,6 +19,7 @@ module.exports = Backbone.Model.extend({
 
   defaults: {
     loading: false,
+    templateSystem: 'handlebars',
     templateAdapter: 'rendr-handlebars'
   },
 
@@ -92,10 +93,11 @@ module.exports = Backbone.Model.extend({
       this.templateAdapter = this.options.templateAdapterInstance;
     } else {
       var templateAdapterModule = attributes.templateAdapter || this.defaults.templateAdapter,
-      templateAdapterOptions = {entryPath: entryPath};
+        templateAdapterOptions = {entryPath: entryPath},
+        templateSystem = require(this.defaults.templateSystem);
 
       templateAdapterOptions = this.setTemplateFinder(templateAdapterOptions);
-      this.templateAdapter = require(templateAdapterModule)(templateAdapterOptions);
+      this.templateAdapter = require(templateAdapterModule)(templateSystem, templateAdapterOptions);
     }
   },
 

--- a/shared/app.js
+++ b/shared/app.js
@@ -94,10 +94,10 @@ module.exports = Backbone.Model.extend({
     } else {
       var templateAdapterModule = attributes.templateAdapter || this.defaults.templateAdapter,
         templateAdapterOptions = {entryPath: entryPath},
-        templateEngine = require(this.defaults.templateEngine);
+        templateEngine = require(attributes.templateEngine || this.defaults.templateEngine);
 
       templateAdapterOptions = this.setTemplateFinder(templateAdapterOptions);
-      this.templateAdapter = require(templateAdapterModule)(templateEngine, templateAdapterOptions);
+      this.templateAdapter = require(templateAdapterModule)(templateAdapterOptions, templateEngine);
     }
   },
 

--- a/shared/app.js
+++ b/shared/app.js
@@ -19,7 +19,7 @@ module.exports = Backbone.Model.extend({
 
   defaults: {
     loading: false,
-    templateSystem: 'handlebars',
+    templateEngine: 'handlebars',
     templateAdapter: 'rendr-handlebars'
   },
 
@@ -94,10 +94,10 @@ module.exports = Backbone.Model.extend({
     } else {
       var templateAdapterModule = attributes.templateAdapter || this.defaults.templateAdapter,
         templateAdapterOptions = {entryPath: entryPath},
-        templateSystem = require(this.defaults.templateSystem);
+        templateEngine = require(this.defaults.templateEngine);
 
       templateAdapterOptions = this.setTemplateFinder(templateAdapterOptions);
-      this.templateAdapter = require(templateAdapterModule)(templateSystem, templateAdapterOptions);
+      this.templateAdapter = require(templateAdapterModule)(templateEngine, templateAdapterOptions);
     }
   },
 

--- a/test/fixtures/app/template_adapter.js
+++ b/test/fixtures/app/template_adapter.js
@@ -1,6 +1,7 @@
-module.exports = function (templateEngine, options) {
+module.exports = function (options, templateEngine) {
   return {
     name: 'Test template adapter',
-    suppliedOptions: options
+    suppliedOptions: options,
+    suppliedTemplateEngine: templateEngine
   };
 }

--- a/test/fixtures/app/template_adapter.js
+++ b/test/fixtures/app/template_adapter.js
@@ -1,4 +1,4 @@
-module.exports = function (templateSystem, options) {
+module.exports = function (templateEngine, options) {
   return {
     name: 'Test template adapter',
     suppliedOptions: options

--- a/test/fixtures/app/template_adapter.js
+++ b/test/fixtures/app/template_adapter.js
@@ -1,4 +1,4 @@
-module.exports = function (options) {
+module.exports = function (templateSystem, options) {
   return {
     name: 'Test template adapter',
     suppliedOptions: options


### PR DESCRIPTION
Add a template system to the defaults, with default value `handlebars` to go along with the default `templateAdapter: 'rendr-handlebars'`.
This would allow us to directly control the version of Handlebars or of the template system that we are using from the Rendr app, instead of being coupled to what's inside the template adapter module.

This needs another PR in `rendr-handlebars` to be merged: https://github.com/rendrjs/rendr-handlebars/pull/52

Thoughts?