### PR TITLE
Fix view hierarchy rendering order when rendering from the client

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -291,9 +291,10 @@ module.exports = BaseView = Backbone.View.extend({
    * plugins like sliders, slideshows, etc.
    */
   _postRender: function() {
-    this.attachChildViews();
-    this.postRender();
-    this.trigger('postRender');
+    this.attachChildViews(function attachChildViews_callback() {
+      this.postRender();
+      this.trigger('postRender');
+    });
   },
 
   /**
@@ -361,7 +362,7 @@ module.exports = BaseView = Backbone.View.extend({
    * Call this.getView()
    * Attach childView
    */
-  attachChildViews: function() {
+  attachChildViews: function(callback) {
     var _baseView = this;
 
     // Remove all child views in case we are re-rendering through
@@ -369,6 +370,7 @@ module.exports = BaseView = Backbone.View.extend({
     this.removeChildViews();
     BaseView.getChildViews(this.app, this, function(views) {
       _baseView.childViews = views;
+      callback.call(_baseView);
     });
   },
 

--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -291,7 +291,7 @@ module.exports = BaseView = Backbone.View.extend({
    * plugins like sliders, slideshows, etc.
    */
   _postRender: function() {
-    this.attachChildViews(function attachChildViews_callback() {
+    this.attachChildViews(function triggerPostRenderActions() {
       this.postRender();
       this.trigger('postRender');
     });

--- a/test/shared/base/view.test.js
+++ b/test/shared/base/view.test.js
@@ -238,6 +238,88 @@ describe('BaseView', function() {
     });
   });
 
+  describe('_postRender', function() {
+    beforeEach(function() {
+      this.app = {
+        modelUtils: modelUtils
+      };
+
+      this.topView = new this.MyTopView({
+        app: this.app
+      });
+    });
+
+    it('should call attachChildViews with a callback function', function() {
+      var spy = sinon.spy(this.topView, 'attachChildViews');
+      this.topView._postRender();
+      var firstArgumentOnFirstCall = spy.args[0][0];
+      expect(typeof firstArgumentOnFirstCall).to.be.deep.equal('function');
+    });
+
+    it('should call postRender', function() {
+      var spy = sinon.spy(this.topView, 'postRender');
+      this.topView._postRender();
+      expect(spy).to.be.called;
+    });
+
+    it("should trigger 'postRender' event", function() {
+      var spy = sinon.spy(this.topView, 'trigger');
+      this.topView._postRender();
+      expect(spy).to.be.calledWith('postRender');
+    });
+  });
+
+  describe('attachChildViews', function() {
+    beforeEach(function() {
+      this.app = {
+        modelUtils: modelUtils
+      };
+
+      this.topView = new this.MyTopView({
+        app: this.app
+      });
+
+      this.callback = sinon.spy();
+    });
+
+    it('should call removeChildViews', function() {
+      var spy = sinon.spy(this.topView, 'removeChildViews');
+      this.topView.attachChildViews(this.callback);
+      spy.should.have.been.called;
+    });
+
+    it('should call BaseView.getChildViews with this and this.app params', function() {
+      var spy = sinon.spy(BaseView, 'getChildViews');
+      this.topView.attachChildViews(this.callback);
+      spy.should.have.been.calledWith(this.topView.app, this.topView);
+      BaseView.getChildViews.restore();
+    });
+
+    it('should call BaseView.getChildViews with a callback function as third param', function() {
+      var spy = sinon.spy(BaseView, 'getChildViews');
+      this.topView.attachChildViews(this.callback);
+      var thirdArgumentOnFirstCall = spy.args[0][2];
+      expect(typeof thirdArgumentOnFirstCall).to.be.deep.equal('function');
+      BaseView.getChildViews.restore();
+    });
+
+    it('should set the chieldViews array with the given views', function() {
+      var myGetChildViews = function(arg1, arg2, callback) {
+        callback(['foo', 'bar']);
+      };
+      sinon.stub(BaseView, 'getChildViews', myGetChildViews);
+
+      this.topView.attachChildViews(this.callback);
+      expect(this.topView.childViews).to.be.deep.equal(['foo', 'bar']);
+      BaseView.getChildViews.restore();
+    });
+
+    it('should call the provided callback with the correct context', function() {
+      this.topView.attachChildViews(this.callback);
+      this.callback.should.have.been.calledOn(this.topView);
+    });
+  });
+
   describe('parseModelAndCollection', function () {
     context('there is a model', function () {
       var MyModel = BaseModel.extend({}),


### PR DESCRIPTION
When calling `this.app.router.redirectTo('some/path')` from the client, the rendering order of views in a parent-child view hierarchy is often not correct.
This is happening because in `_postRender` we call `attachChildViews` and then immediately trigger the `postRender` event, without waiting for `attachChildViews` itself to be completed.
In AMD environment, this often results in child views firing postRender before parent views, or in random order anyway. 
The solution is as simple as firing `postRender` only when the child views are attached, using a callback for it.

Please let me know if this is not clear. 
What do you think?