### PR TITLE
allow x-http-method-override header to be passed in from the client request

### DIFF
--- a/server/middleware/apiProxy.js
+++ b/server/middleware/apiProxy.js
@@ -24,6 +24,8 @@ function apiProxy(dataAdapter) {
       'x-forwarded-for': apiProxy.getXForwardedForHeader(req.headers, req.ip)
     };
 
+    api.headers = apiProxy.setXHTTPMethodOverride(req.headers, api.headers);
+
     dataAdapter.request(req, api, {
       convertErrorCode: false
     }, function(err, response, body) {
@@ -64,4 +66,11 @@ apiProxy.getXForwardedForHeader = function (headers, clientIp) {
   }
 
   return newHeaderValue;
+};
+
+apiProxy.setXHTTPMethodOverride = function (requestHeaders, apiHeaders) {
+  if (requestHeaders['x-http-method-override']) {
+    apiHeaders['x-http-method-override'] = requestHeaders['x-http-method-override'];
+  }
+  return apiHeaders;
 };

--- a/test/server/middleware/apiProxy.test.js
+++ b/test/server/middleware/apiProxy.test.js
@@ -85,6 +85,33 @@ describe('apiProxy', function() {
         incomingHeaders['x-forwarded-for']);
     });
 
+    it('should add an x-http-method-override header to the request if there is one', function () {
+      var incomingHeaders = { 'x-http-method-override': 'PUT' },
+        outgoingHeaders;
+
+      requestFromClient.headers = incomingHeaders;
+
+      proxy(requestFromClient, responseToClient);
+
+      requestToApi.should.have.been.calledOnce;
+      outgoingHeaders = requestToApi.firstCall.args[1].headers;
+      outgoingHeaders['x-http-method-override'].should.eq(incomingHeaders['x-http-method-override']);
+    });
+
+    it('should not add an x-http-method-override header to the request if there is not one', function () {
+      var incomingHeaders = {},
+        outgoingHeaders;
+
+      requestFromClient.headers = incomingHeaders;
+
+      proxy(requestFromClient, responseToClient);
+
+      requestToApi.should.have.been.calledOnce;
+      outgoingHeaders = requestToApi.firstCall.args[1].headers;
+
+      expect(outgoingHeaders['x-http-method-override']).to.be.undefined;
+    });
+
 
    it('should not pass through the host header', function () {
       proxy(requestFromClient, responseToClient);


### PR DESCRIPTION
This would allow more flexibility into `apiProxy`, allowing the usage of the `x-http-method-override header`. Currently, if we try to to use Backbone's `emulateHTTP` option ( http://backbonejs.org/#Sync-emulateHTTP), the header set from the client is then discarded by the Rendr app.