### PR TITLE
Add a leading / to backbone route misses to prevent routes being appended

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -206,9 +206,7 @@ ClientRouter.prototype.redirectTo = function(path, options) {
 
   if (options.pushState === false) {
     // Do a full-page redirect.
-    // add a leading slash so path is not appended
-    if (path.charAt(0) !== '/') path = '/' + path;
-    window.location.href = path;
+    this.exitApp(path);
   } else {
     // Do a pushState navigation.
     hashParts = path.split('#');
@@ -225,6 +223,19 @@ ClientRouter.prototype.redirectTo = function(path, options) {
     this.navigate(path, options);
   }
 };
+
+ClientRouter.prototype.exitApp = function (path) {
+  var exitPath = this.noRelativePath(path);
+  window.location.href = exitPath;
+}
+
+ClientRouter.prototype.noRelativePath = function (path) {
+  //if it's not a full url or already has a leading slash
+  if (path.indexOf('://') == -1 && path.charAt(0) !== '/') {
+    path = '/' + path;
+  }
+  return path;
+}
 
 ClientRouter.prototype.handleErr = function(err, route) {
   this.trigger('action:error', err, route);

--- a/client/router.js
+++ b/client/router.js
@@ -206,6 +206,8 @@ ClientRouter.prototype.redirectTo = function(path, options) {
 
   if (options.pushState === false) {
     // Do a full-page redirect.
+    // add a leading slash so path is not appended
+    if (path.charAt(0) !== '/') path = '/' + path;
     window.location.href = path;
   } else {
     // Do a pushState navigation.

--- a/test/client/router.test.js
+++ b/test/client/router.test.js
@@ -1,5 +1,6 @@
 var should = require('chai').should(),
     App = require('../../shared/app'),
+    sinon = require('sinon'),
     clientTestHelper = require('../helpers/client_test');
 
 describe("client/router", function() {
@@ -42,4 +43,36 @@ describe("client/router", function() {
     });
   });
 
+  describe('Redirecting', function(){
+    it("should send a full url out of the app", function(done) {
+      var url = 'http://www.example.com';
+      var stub = sinon.stub(this.router, 'exitApp');
+      this.router.navigate(url);
+      expect(stub.called).to.equal(true);
+      done();
+    });
+    it("should send an unmatched route out of the app", function(done) {
+      var path = '/no/route/match';
+      var stub = sinon.stub(this.router, 'exitApp');
+      this.router.navigate(path);
+      expect(stub.called).to.equal(true);
+      done();
+    });
+    it("should not modify full urls", function(done) {
+      var paths = ['http://www.foo.com', 'https://foo.com', '//foo.com'];
+      var self = this;
+      paths.forEach(function(path){
+        expect(self.router.noRelativePath(path)).to.equal(path);
+      });
+      done();
+    });
+    it("paths should all be prefixed with a /", function(done) {
+      var paths = ['/a/root', 'a/rel/', 'a//rel/', '/a//root/'];
+      var self = this;
+      paths.forEach(function(path){
+        expect(self.router.noRelativePath(path).charAt(0)).to.equal('/');
+      });
+      done();
+    });
+  });
 });


### PR DESCRIPTION
in a situation where there was a link like

```html
<a href="/path/not/in/rendr/routes">stuff</a>
```
On the page at `www.example.com/user/123`.  The app would end up redirecting to:

```
www.example.com/user/123/path/not/in/rendr/routes
```

instead of

```
www.example.com/path/not/in/rendr/routes
```

due to the path that's passed to the client router _never_ having a leading slash.

If a link is known to not be in Rendr, you can add the `data-pass-thru` element to the link and everything will work properly.  We can't always do that since we have separate Rendr apps on `/foo` and `/bar`  that link to each other with shared code that shouldn't always be `data-pass-thru` links.  I also think that this PR matches the intent of the code.

I kinda think that this used to work, but may have changed in the Backbone update (there were some other breaking changes, too lazy to try and old version and see :-). But really, I don't know. We're doing some new stuff with our Rendr.  The breaking HTML concern here is that it prevents relative urls that don't have routes.  E.g. using the `/user/123` setup above but linking to:

```html
<a href="photos">user's photos</a>
```

but wanting `/user/123/photos` to miss Rendr.

I don't know how popular this particular code path is, so I'm very much willing to be told that it's working fine. Or that instead of using `window.location.href` it should just use `Backbone.router.jeremysRedirect(path)` or something.  I don't know the Backbone router internals that well (I know them ok, but could certainly be missing a method / option combo feature).

The express side router handles route misses properly. 

/cc @saponifi3d @alexindigo @purusho 