### PR TITLE
Do not fill in inner html on the server-side for a lazy-loaded view

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -195,7 +195,7 @@ module.exports = BaseView = Backbone.View.extend({
    * Get the HTML for the view, including the wrapper element.
    */
   getHtml: function() {
-    var html = this.getInnerHtml(),
+    var html = this.options.lazy ? '' : this.getInnerHtml(),
         attributes = this.getAttributes(),
         tagName = _.result(this, "tagName"),
         attrString;

--- a/test/shared/base/view.test.js
+++ b/test/shared/base/view.test.js
@@ -151,6 +151,38 @@ describe('BaseView', function() {
     });
   });
 
+  describe('getHtml', function() {
+    var view;
+
+    beforeEach(function() {
+      this.View = BaseView.extend({
+        id: 'aViewId',
+        className: 'aClassName',
+        name: 'A View Name'
+      });
+    });
+
+    context('is not a lazy-loaded view', function() {
+      it('should get the HTML for the view, including the wrapper element', function() {
+        view = new this.View({app: this.app});
+        sinon.stub(view, 'getInnerHtml').returns('INNER HTML');
+
+        view.getHtml().should.equal('<div id="aViewId" class="aClassName" data-view="A View Name">INNER HTML</div>');
+        view.getInnerHtml.should.have.been.called;
+      });
+    });
+
+    context('is a lazy-loaded view', function() {
+      it('should only return the wrapper element HTML', function() {
+        view = new this.View({lazy: true, app: this.app});
+        sinon.stub(view, 'getInnerHtml').returns('INNER HTML');
+
+        view.getHtml().should.equal('<div id="aViewId" class="aClassName" data-view="A View Name" data-lazy="true"></div>');
+        view.getInnerHtml.should.not.have.been.called;
+      });
+    });
+  });
+
   describe('parseOptions', function () {
     var view;
 


### PR DESCRIPTION
I've been getting server-side errors when attempting to lazy-load a view that accesses properties on the model/collection in `getTemplateData`.

The reason is that in the rendr-handlebars `view` helper, a call is made to get server html https://github.com/rendrjs/rendr-handlebars/blob/master/shared/helpers/view.js#L55, but that call does not take into account whether the view is to be loaded lazily on the client before invoking `getInnerHtml` server-side.

`getInnerHtml` attempts to fill in the template data, which in turn accesses model/collection properties on the server when the data hasn't been fetched yet and fails.