### PR TITLE
Attach views back in series instead of async

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -491,7 +491,7 @@ BaseView.getChildViews = function(app, parentView, callback) {
   var scope = parentView ? parentView.$el : null,
       list = Backbone.$('[data-view]', scope).toArray();
 
-  async.map(list, function(el, cb) {
+  async.mapSeries(list, function(el, cb) {
     var $el, options, viewName, fetchSummary;
     $el = Backbone.$(el);
     if (!$el.data('view-attached')) {


### PR DESCRIPTION
When using rendr with `requirejs` in AMD mode the child views are attached with `null` as parent on the first render. Because we are waiting for the module to be loaded . This change is to forcefully attach the views in series. 