### PR TITLE
Include statusText in error object

### DIFF
--- a/shared/fetcher.js
+++ b/shared/fetcher.js
@@ -187,6 +187,7 @@ Fetcher.prototype.fetchFromApi = function(spec, options, callback) {
         respOutput = JSON.stringify(resp);
         err = new Error("ERROR fetching model '" + fetcher.modelUtils.modelName(model.constructor) + "' with options '" + JSON.stringify(options) + "'. Response: " + respOutput);
         err.status = resp.status;
+        err.statusText = resp.statusText;
         err.body = body;
         callback(err);
       }

--- a/shared/syncer.js
+++ b/shared/syncer.js
@@ -48,7 +48,8 @@ function clientSync(method, model, options) {
       }
       resp = {
         body: body,
-        status: xhr.status
+        status: xhr.status,
+        statusText: xhr.statusText
       };
       error(resp);
     }


### PR DESCRIPTION
When using timeout option for XHR, the error objects needs to differentiate between timeouts and other errors if the applications should be able to handle these differently.