### PR TITLE
Fix client side issue when partial view is nested in another partial view

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -468,7 +468,7 @@ BaseView.getViewOptions = function ($el) {
     options = $el.data();
 
   _.each(options, function(value, key) {
-    if (_.isString(value)) {
+    if (_.isString(value) && key !== '_block') {
       parsed = _.unescape(value);
       try {
         parsed = JSON.parse(parsed);
@@ -476,6 +476,10 @@ BaseView.getViewOptions = function ($el) {
       options[key] = parsed;
     }
   });
+
+  if (options && options._block && options._block.string) {
+    options._block = options._block.string;
+  }
 
   return options;
 };


### PR DESCRIPTION
A view that is comprised of nested partial views fails when rendered on the client.

example emblem setup would be:

partial_1.emblem:

div
  h2 Partial 1
  == _block

partial_2.emblem:

div
  h2 Partial 2
  == _block

sub_view.emblem:

h2 Sub View

main_view.emblem:

= view partial_1
  =view partial_2
    = sub_view