### PR TITLE
Don't unescape view options

### DIFF
--- a/shared/base/view.js
+++ b/shared/base/view.js
@@ -464,16 +464,14 @@ BaseView.createChildView = function (ViewClass, options, $el, parentView, cb) {
 };
 
 BaseView.getViewOptions = function ($el) {
-  var parsed,
-    options = $el.data();
+  var options = $el.data();
 
   _.each(options, function(value, key) {
     if (_.isString(value)) {
-      parsed = _.unescape(value);
       try {
-        parsed = JSON.parse(parsed);
+        value = JSON.parse(value);
       } catch (err) {}
-      options[key] = parsed;
+      options[key] = value;
     }
   });
 

--- a/test/shared/base/view.test.js
+++ b/test/shared/base/view.test.js
@@ -787,4 +787,26 @@ describe('BaseView', function() {
       expect(newChildView).to.be.an.instanceOf(ViewClass);
     });
   });
+
+  describe('BaseView.getViewOptions', function() {
+    it('should not unescape escaped data', function() {
+      var fakeEl = {
+        data: _.constant({
+          normalOption: 'Normal data',
+          jsonOption: '{"json":"data"}',
+          escapedOption: 'I am &lt;span&gt;escaped&lt;/span&gt;',
+          escapedJsonOption: '{"escapedData":"I am &lt;span&gt;escaped&lt;/span&gt;"}'
+        })
+      }
+
+      var parsedOptions = BaseView.getViewOptions(fakeEl);
+
+      expect(parsedOptions).to.deep.equal({
+        normalOption: 'Normal data',
+        jsonOption: {json: 'data'},
+        escapedOption: 'I am &lt;span&gt;escaped&lt;/span&gt;',
+        escapedJsonOption: {escapedData: 'I am &lt;span&gt;escaped&lt;/span&gt;'}
+      });
+    });
+  });
 });


### PR DESCRIPTION
These are automatically unescaped whenever they are rendered to the DOM, so doing it here actually unescapes the content too many times, opening up a potential XSS vector, e.g. when displaying escaped HTML in a _block.

See rendrjs/rendr-handlebars#61 for a more detailed explanation