### PR TITLE
URI encode interpolated parameter value

### DIFF
--- a/shared/syncer.js
+++ b/shared/syncer.js
@@ -188,7 +188,7 @@ syncer.interpolateParams = function interpolateParams(model, url, params) {
       } else {
         value = model.get(property);
       }
-      url = url.replace(param, value);
+      url = url.replace(param, encodeURIComponent(value));
 
       /**
        * Delete the param from params hash, so we don't get urls like:

--- a/test/shared/syncer.test.js
+++ b/test/shared/syncer.test.js
@@ -70,6 +70,24 @@ describe('syncer', function() {
           request.should.have.been.calledWith(model.app.req, expectedRequestOptions)
         });
 
+        it('should encode non-latin param values', function () {
+          model.set('id', 'президент');
+
+          var expectedRequestOptions = {
+            method: 'GET',
+            path: '/listings/%D0%BF%D1%80%D0%B5%D0%B7%D0%B8%D0%B4%D0%B5%D0%BD%D1%82',
+            query: { baz: { quux: 'doh' } },
+            headers: { foo: 'bar' },
+            api: 'foo',
+            body: {}
+          };
+
+          syncer.serverSync.call(model, 'read', model, options);
+
+          request.should.have.been.calledOnce;
+          request.should.have.been.calledWith(model.app.req, expectedRequestOptions)
+        });
+
         it('should send the correct payload on PUT or POST requests', function () {
           var expectedRequestOptions = {
             method: 'PUT',
@@ -100,6 +118,24 @@ describe('syncer', function() {
             var expectedRequestOptions = {
               method: 'GET',
               path: '/listings/0',
+              query: { baz: { quux: 'doh' } },
+              headers: { foo: 'bar' },
+              api: 'foo',
+              body: {}
+            };
+
+            syncer.serverSync.call(model, 'read', model, options);
+
+            request.should.have.been.calledOnce;
+            request.should.have.been.calledWith(model.app.req, expectedRequestOptions)
+          });
+
+          it('should encode non-latin param values', function () {
+            model.set('id', 'президент');
+
+            var expectedRequestOptions = {
+              method: 'GET',
+              path: '/listings/%D0%BF%D1%80%D0%B5%D0%B7%D0%B8%D0%B4%D0%B5%D0%BD%D1%82',
               query: { baz: { quux: 'doh' } },
               headers: { foo: 'bar' },
               api: 'foo',


### PR DESCRIPTION
It seems like there is a discrepancy with how URL encoding takes place.

Given a model `var UserModel = BaseModel.extend({urlRoot: '/users'})`, we can fetch it with a spec `{model: 'UserModel', params: {id: 'президент'}}` and the URL fetched will be `/users/%D0%BF%D1%80%D0%B5%D0%B7%D0%B8%D0%B4%D0%B5%D0%BD%D1%82` thanks to [Backbone's `url` method](http://backbonejs.org/docs/backbone.html#section-90) applying a `encodeURIComponent` to the ID.

With a collection `var UserOrderCollection = BaseCollection.extend({url: '/users/:user_id/orders'})` and a fetch spec `{collection: 'UserOrderCollection', params: {user_id: 'президент'}}`, no encoding is applied and so the URL requested is `/users/президент/orders`.

Upgrading from Node 0.10.30 to a later version has revealed this for us. It seems that newer Node versions might do less automatic escaping of outbound URLs.

This PR attempts to give us consistency over the encoding of dynamically constructed URLs.