### PR TITLE
Explicitly check for data-pass-thru to be true

### DIFF
--- a/client/app_view.js
+++ b/client/app_view.js
@@ -35,7 +35,7 @@ module.exports = BaseView.extend({
   },
 
   _bindInterceptClick: function() {
-    this.$el.on('click', 'a:not([data-pass-thru])', this._interceptClick.bind(this));
+    this.$el.on('click', 'a:not([data-pass-thru="true"])', this._interceptClick.bind(this));
   },
 
   _interceptClick: function(e) {


### PR DESCRIPTION
At least in the way we've been using it, we always set `data-pass-thru="true"` when we mean it. This seemed to indicate that if `data-pass-thru` was set to "false" it would catch links clicked to be handled by the Rendr app - not the case. This change makes it explicit that `data-pass-thru="true"` means Rendr won't be handling the link.

@saponifi3d @jmerrifield 
